### PR TITLE
Add ability to filter by type

### DIFF
--- a/mcc/ttl/main.go
+++ b/mcc/ttl/main.go
@@ -16,6 +16,8 @@ var wait bool
 
 type filter []string
 
+var entryTypeFlag filter
+
 func (f *filter) String() string {
 	return fmt.Sprint(*f)
 }
@@ -196,11 +198,18 @@ func main() {
 	ttl := flag.Int64("ttl", 300, "Desired TTL value")
 	flag.BoolVar(&verbose, "v", false, "Increments output")
 	flag.BoolVar(&wait, "w", false, "Waits for changes to complete")
+	flag.Var(&entryTypeFlag, "t", "comma-separated list of entry record types")
 
 	flag.Parse()
 
 	if *zoneName == "" {
 		log.Fatal("Insufficient input parameters!")
+	}
+
+	if len(entryTypeFlag) == 0 {
+		for _, f := range []string{"A", "AAAA", "CNAME", "MX", "NAPTR", "PTR", "SPF", "SRV", "TXT"} {
+			entryTypeFlag = append(entryTypeFlag, f)
+		}
 	}
 
 	sess, err := session.NewSession()
@@ -231,18 +240,7 @@ func main() {
 	}
 	list := GetResourceRecordSet(params2, svc)
 	// Filter list in between
-	filter := []string{
-		"A",
-		"AAAA",
-		"CNAME",
-		"MX",
-		"NAPTR",
-		"PTR",
-		"SPF",
-		"SRV",
-		"TXT",
-	}
-	list = FilterResourceRecordSetType(list, filter)
+	list = FilterResourceRecordSetType(list, entryTypeFlag)
 	changeResponse, err := UpsertResourceRecordSetTTL(list, *ttl, zoneID, svc)
 	if err != nil {
 		log.Panic(err.Error())

--- a/mcc/ttl/main.go
+++ b/mcc/ttl/main.go
@@ -7,11 +7,25 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"log"
+	"strings"
 	"time"
 )
 
 var verbose bool
 var wait bool
+
+type filter []string
+
+func (f *filter) String() string {
+	return fmt.Sprint(*f)
+}
+
+func (f *filter) Set(value string) error {
+	for _, val := range strings.Split(value, ",") {
+		*f = append(*f, val)
+	}
+	return nil
+}
 
 // GetResourceRecordSet returns a slice containing all responses for specified
 // query. It may issue more than one request as each returns a fixed amount of


### PR DESCRIPTION
Adds -t flag to specify a filter on the type of DNS entry. This flag can be specified several times and can specify several entries at once separated by commas. Repeated types will cause more changes but results shouldn't be affected.

If the flag is not specified, it automatically filters so only fields of the following types are affected:
* A
* AAAA
* CNAME
* MX 
* NAPTR
* PTR
* SPF
* SRV
* TXT