### PR TITLE
Rework filtering for ttl

### DIFF
--- a/mcc/ttl/cmd/main.go
+++ b/mcc/ttl/cmd/main.go
@@ -15,6 +15,7 @@ var myttl int64
 var verbose bool
 var wait bool
 var dryrun bool
+var exclude bool
 var entryTypeFlag ttl.Filter
 var entryNameFlag ttl.Filter
 
@@ -25,6 +26,12 @@ func Init() {
 	flag.BoolVar(&verbose, "v", false, "Increments output")
 	flag.BoolVar(&wait, "w", false, "Waits for changes to complete")
 	flag.BoolVar(&dryrun, "dryrun", false, "Does not commit the changes")
+	flag.BoolVar(
+		&exclude,
+		"exclude",
+		false,
+		"Filter lists are used to exclude records instead of including them",
+	)
 	flag.Var(&entryTypeFlag,
 		"t",
 		"Comma-separated list of entry record types")
@@ -57,6 +64,59 @@ func Init() {
 	ttl.Dryrun = dryrun
 }
 
+func filter(l []*route53.ResourceRecordSet) []*route53.ResourceRecordSet {
+	list := l
+	if exclude {
+		log.Println("Exclude!")
+		list = ttl.FilterResourceRecords(
+			l,
+			entryTypeFlag,
+			func(elem *route53.ResourceRecordSet, filter string) *route53.ResourceRecordSet {
+				if *elem.Name != filter {
+					return elem
+				}
+				return nil
+			},
+		)
+		if len(entryNameFlag) > 0 {
+			list = ttl.FilterResourceRecords(
+				list,
+				entryNameFlag,
+				func(elem *route53.ResourceRecordSet, filter string) *route53.ResourceRecordSet {
+					if *elem.Name != filter {
+						return elem
+					}
+					return nil
+				},
+			)
+		}
+	} else {
+		list = ttl.FilterResourceRecords(
+			l,
+			entryTypeFlag,
+			func(elem *route53.ResourceRecordSet, filter string) *route53.ResourceRecordSet {
+				if *elem.Name == filter {
+					return elem
+				}
+				return nil
+			},
+		)
+		if len(entryNameFlag) > 0 {
+			list = ttl.FilterResourceRecords(
+				list,
+				entryNameFlag,
+				func(elem *route53.ResourceRecordSet, filter string) *route53.ResourceRecordSet {
+					if *elem.Name == filter {
+						return elem
+					}
+					return nil
+				},
+			)
+		}
+	}
+	return list
+}
+
 func main() {
 	Init()
 	sess, err := session.NewSession()
@@ -70,11 +130,7 @@ func main() {
 
 	list := ttl.GetResourceRecordSet(zoneID, svc)
 	// Filter list in between
-	list = ttl.FilterResourceRecordSetType(list, entryTypeFlag)
-	list, list2 := ttl.SplitResourceRecordSetTypeOnNames(list, entryNameFlag)
-	if len(list2) > 0 {
-		list = list2
-	}
+	list = filter(list)
 	changeResponse, err := ttl.UpsertResourceRecordSetTTL(list, myttl, &zoneID, svc)
 	if err != nil {
 		log.Panic(err.Error())

--- a/mcc/ttl/ttl.go
+++ b/mcc/ttl/ttl.go
@@ -164,35 +164,18 @@ func PrintRecords(
 	return
 }
 
-// FilterResourceRecordSetType returns a slice containing only the entries with
-// specified types of the original record slice
-func FilterResourceRecordSetType(
+// FilterResourceRecords returns a slice containing only the entries that
+// pass the check performed by the function argument
+func FilterResourceRecords(
 	l []*route53.ResourceRecordSet,
 	f []string,
+	p func(*route53.ResourceRecordSet, string) *route53.ResourceRecordSet,
 ) (result []*route53.ResourceRecordSet) {
 	for _, elem := range l {
 		for _, filter := range f {
-			if *elem.Type == filter {
-				result = append(result, elem)
-			}
-		}
-	}
-	return
-}
-
-// SplitResourceRecordSetTypeOnNames returns two slices: one containing all the
-// entries from the l argument, and another with the results of excluding the
-// matches from the f argument.
-func SplitResourceRecordSetTypeOnNames(
-	l []*route53.ResourceRecordSet,
-	f []string,
-) (result1 []*route53.ResourceRecordSet, result2 []*route53.ResourceRecordSet) {
-	result1 = l
-	for _, elem := range l {
-		for _, filter := range f {
-			if *elem.Name == filter {
-				result2 = append(result2, elem)
-				break
+			res := p(elem, filter)
+			if res != nil {
+				result = append(result, res)
 			}
 		}
 	}


### PR DESCRIPTION
This refactors the way we do filtering on ttl. Improves tests related to filtering and introduces a new flag to modify the behaviour from including results to excluding the filters.