### PR TITLE
Improve capcom's graphing related functions

### DIFF
--- a/mcc/capcom/capcom/graphing.go
+++ b/mcc/capcom/capcom/graphing.go
@@ -45,9 +45,9 @@ func getInstances(svc ec2iface.EC2API) *ec2.DescribeInstancesOutput {
 	return resp
 }
 
-func getInstancesStates(instances *ec2.DescribeInstancesOutput) sGInstanceState {
+func getInstancesStates(instances []*ec2.Reservation) sGInstanceState {
 	iState := make(sGInstanceState)
-	for _, res := range instances.Reservations {
+	for _, res := range instances {
 		state := map[string]int{
 			"pending":       0,
 			"running":       0,
@@ -181,7 +181,7 @@ func GraphSGRelations(svc ec2iface.EC2API) string {
 	}
 	log.Println("Created graph")
 
-	nodesPresence := getInstancesStates(getInstances(svc))
+	nodesPresence := getInstancesStates(getInstances(svc).Reservations)
 	registerNodes(sglist, g, nodesPresence)
 	registerEdges(sglist, g, nodesPresence)
 	return g.String()

--- a/mcc/capcom/capcom/graphing.go
+++ b/mcc/capcom/capcom/graphing.go
@@ -94,7 +94,9 @@ func registerNodes(
 			nodesPresence[*sg.GroupId]["stopped"] == 0:
 			attrs["color"] = "red"
 		}
-		graph.AddNode("G", *sg.GroupId, attrs)
+		if err := graph.AddNode("G", *sg.GroupId, attrs); err != nil {
+			log.Println(err)
+		}
 		if nodesPresence[*sg.GroupId] == nil {
 			nodesPresence[*sg.GroupId] = nil
 		}
@@ -151,12 +153,14 @@ func registerEdges(
 						groupName,
 						*pair.GroupId,
 					)
-					graph.AddEdge(
+					if err := graph.AddEdge(
 						*sg.GroupId,
 						*pair.GroupId,
 						true,
 						edgeAttrs(perm),
-					)
+					); err != nil {
+						log.Println(err)
+					}
 				}
 			}
 		}
@@ -169,8 +173,12 @@ func GraphSGRelations(svc ec2iface.EC2API) string {
 	sglist := getSecurityGroups(svc).SecurityGroups
 
 	g := gographviz.NewEscape()
-	g.SetName("G")
-	g.SetDir(true)
+	if err := g.SetName("G"); err != nil {
+		log.Println(err)
+	}
+	if err := g.SetDir(true); err != nil {
+		log.Println(err)
+	}
 	log.Println("Created graph")
 
 	nodesPresence := getInstancesStates(getInstances(svc))

--- a/mcc/capcom/capcom/graphing.go
+++ b/mcc/capcom/capcom/graphing.go
@@ -44,7 +44,6 @@ func getInstancesPerSG(svc ec2iface.EC2API) sGInstanceState {
 		log.Panic(err.Error())
 	}
 	for _, res := range resp.Reservations {
-		groupID := []string{}
 		state := map[string]int{
 			"pending":       0,
 			"running":       0,
@@ -53,14 +52,11 @@ func getInstancesPerSG(svc ec2iface.EC2API) sGInstanceState {
 			"stopping":      0,
 			"stopped":       0,
 		}
-		for _, group := range res.Groups {
-			groupID = append(groupID, *group.GroupId)
-		}
 		for _, instance := range res.Instances {
 			state[*instance.State.Name]++
 		}
-		for _, gid := range groupID {
-			iState[gid] = state
+		for _, group := range res.Groups {
+			iState[*group.GroupId] = state
 		}
 	}
 	return iState

--- a/mcc/capcom/capcom/graphing_test.go
+++ b/mcc/capcom/capcom/graphing_test.go
@@ -7,6 +7,26 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
+func TestSGInstanceStateGetKeysAndHas(t *testing.T) {
+	sg := make(sGInstanceState)
+	empty := map[string]int{}
+
+	keyList := []string{"first", "second", "third"}
+	for _, v := range keyList {
+		sg[v] = empty
+	}
+
+	length := len(sg.getKeys())
+	if length != 3 {
+		t.Errorf("Expected length 3, found %d.\n", length)
+	}
+	for _, v := range keyList {
+		if !sg.has(v) {
+			t.Errorf("Expected value \"%s\" not found.", v)
+		}
+	}
+}
+
 var describeInstancesOutput = ec2.DescribeInstancesOutput{
 	Reservations: []*ec2.Reservation{
 		{

--- a/mcc/capcom/capcom/graphing_test.go
+++ b/mcc/capcom/capcom/graphing_test.go
@@ -1,0 +1,45 @@
+package capcom
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+)
+
+var describeInstancesOutput = ec2.DescribeInstancesOutput{
+	Reservations: []*ec2.Reservation{
+		{
+			Instances: []*ec2.Instance{
+				{
+					State: &ec2.InstanceState{
+						Name: aws.String("pending"),
+					},
+				},
+			},
+			Groups: []*ec2.GroupIdentifier{
+				{
+					GroupId: aws.String("sg-12345678"),
+				},
+			},
+		},
+	},
+}
+
+func (m *mockEC2Client) DescribeInstances(
+	in *ec2.DescribeInstancesInput,
+) (
+	out *ec2.DescribeInstancesOutput,
+	err error,
+) {
+	return &describeInstancesOutput, nil
+}
+
+func TestGetInstances(t *testing.T) {
+	svc := &mockEC2Client{}
+	res := getInstances(svc)
+	if *res.Reservations[0].Instances[0].State.Name != "pending" ||
+		*res.Reservations[0].Groups[0].GroupId != "sg-12345678" {
+		t.Error("Should be equal")
+	}
+}

--- a/mcc/capcom/capcom/graphing_test.go
+++ b/mcc/capcom/capcom/graphing_test.go
@@ -43,3 +43,17 @@ func TestGetInstances(t *testing.T) {
 		t.Error("Should be equal")
 	}
 }
+
+func TestGetInstancesStates(t *testing.T) {
+	res := getInstancesStates(describeInstancesOutput.Reservations)
+	if len(res) != 1 {
+		t.Error("Unexpected amount of results")
+	}
+	if state := res["sg-12345678"]; state != nil {
+		if state["pending"] != 1 {
+			t.Error("Unexpected values")
+		}
+	} else {
+		t.Error("Expected key missing")
+	}
+}


### PR DESCRIPTION
Split a big method ans add tests

**Clean up machine state info gathering**

**Split getInstancesPerSG**
This one's a misnomer and too many concerns. This will ease adding
tests to this code.

**Add basic error handling for gographviz functions**

**Add testing for graphing functions**

**Improve signature of getInstancesStates**

**Add test for getInstanecesStates**

**Add test for sGInstanceState methods**

