### PR TITLE
Add shortener client

### DIFF
--- a/mcc/short/cmd/add.go
+++ b/mcc/short/cmd/add.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/poka-yoke/spaceflight/mcc/short/short"
+)
+
+var apiKey, addURL string
+var domain, path, url string
+
+// addCmd represents the add command
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "add [flags]",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		svc := short.NewService().SetAPIKey(apiKey)
+		svc.AddURL = addURL
+
+		err := svc.Add(domain, path, url)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(addCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// addCmd.PersistentFlags().String("foo", "", "A help for foo")
+	addCmd.PersistentFlags().StringVarP(
+		&domain,
+		"domain",
+		"",
+		"",
+		"Domain for the shortener URL",
+	)
+	addCmd.PersistentFlags().StringVarP(
+		&path,
+		"path",
+		"",
+		"",
+		"Path for the shortener URL",
+	)
+	addCmd.PersistentFlags().StringVarP(
+		&url,
+		"url",
+		"",
+		"",
+		"Destination for the shortened URL",
+	)
+	addCmd.PersistentFlags().StringVarP(
+		&apiKey,
+		"apikey",
+		"",
+		"",
+		"API key for the shortener service",
+	)
+	addCmd.PersistentFlags().StringVarP(
+		&addURL,
+		"addURL",
+		"",
+		"",
+		"Base URL for the Add endpoint",
+	)
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/mcc/short/cmd/root.go
+++ b/mcc/short/cmd/root.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var cfgFile string
+
+// RootCmd represents the base command when called without any subcommands
+var RootCmd = &cobra.Command{
+	Use:   "short",
+	Short: "CLI client for shortener's API",
+	Long:  ``,
+	// Uncomment the following line if your bare application
+	// has an action associated with it:
+	//	Run: func(cmd *cobra.Command, args []string) { },
+}
+
+// Execute adds all child commands to the root command sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() {
+	if err := RootCmd.Execute(); err != nil {
+		fmt.Println(err)
+		os.Exit(-1)
+	}
+}
+
+func init() {
+	cobra.OnInitialize(initConfig)
+
+	// Here you will define your flags and configuration settings.
+	// Cobra supports Persistent Flags, which, if defined here,
+	// will be global for your application.
+
+	RootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.short.yaml)")
+	// Cobra also supports local flags, which will only run
+	// when this action is called directly.
+	RootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+// initConfig reads in config file and ENV variables if set.
+func initConfig() {
+	if cfgFile != "" { // enable ability to specify config file via flag
+		viper.SetConfigFile(cfgFile)
+	}
+
+	viper.SetConfigName(".short") // name of config file (without extension)
+	viper.AddConfigPath("$HOME")  // adding home directory as first search path
+	viper.AutomaticEnv()          // read in environment variables that match
+
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err == nil {
+		fmt.Println("Using config file:", viper.ConfigFileUsed())
+	}
+}

--- a/mcc/short/cmd/update.go
+++ b/mcc/short/cmd/update.go
@@ -1,0 +1,74 @@
+package cmd
+
+import (
+	"log"
+
+	"github.com/spf13/cobra"
+
+	"github.com/poka-yoke/spaceflight/mcc/short/short"
+)
+
+// updateCmd represents the update command
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "update [flags]",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		svc := short.NewService().SetAPIKey(apiKey)
+		svc.AddURL = addURL
+
+		err := svc.Update(domain, path, url)
+		if err != nil {
+			log.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(updateCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// updateCmd.PersistentFlags().String("foo", "", "A help for foo")
+	updateCmd.PersistentFlags().StringVarP(
+		&domain,
+		"domain",
+		"",
+		"",
+		"Domain for the shortener URL",
+	)
+	updateCmd.PersistentFlags().StringVarP(
+		&path,
+		"path",
+		"",
+		"",
+		"Path for the shortener URL",
+	)
+	updateCmd.PersistentFlags().StringVarP(
+		&url,
+		"url",
+		"",
+		"",
+		"Destination for the shortened URL",
+	)
+	updateCmd.PersistentFlags().StringVarP(
+		&apiKey,
+		"apikey",
+		"",
+		"",
+		"API key for the shortener service",
+	)
+	updateCmd.PersistentFlags().StringVarP(
+		&addURL,
+		"addURL",
+		"",
+		"",
+		"Base URL for the Add endpoint",
+	)
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// updateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+}

--- a/mcc/short/main.go
+++ b/mcc/short/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/poka-yoke/spaceflight/mcc/short/cmd"
+
+func main() {
+	cmd.Execute()
+}

--- a/mcc/short/short/short.go
+++ b/mcc/short/short/short.go
@@ -8,15 +8,18 @@ import (
 	"net/http"
 )
 
+// NewService returns an empty Service
 func NewService() *Service {
 	return &Service{}
 }
 
+// Service holds identification and back-end methods
 type Service struct {
 	aPIKey            string
 	AddURL, UpdateURL string
 }
 
+// SetAPIKey Configures the API Key in the Service
 func (s *Service) SetAPIKey(key string) *Service {
 	s.aPIKey = key
 	return s
@@ -60,7 +63,7 @@ func (s Service) Body(domain, path, url string) (out io.Reader) {
 	return
 }
 
-// Request to add entry
+// Request to Service
 func (s Service) Request(method string, body io.Reader) (req *http.Request, err error) {
 	req, err = http.NewRequest(method, s.AddURL, body)
 	if err != nil {
@@ -71,7 +74,7 @@ func (s Service) Request(method string, body io.Reader) (req *http.Request, err 
 	return
 }
 
-// Do executes the request to add an entry
+// Do sends the request to the Service and returns the response for validation
 func (s Service) Do(req *http.Request) (res *http.Response, err error) {
 	res, err = http.DefaultClient.Do(req)
 	if err != nil {

--- a/mcc/short/short/short.go
+++ b/mcc/short/short/short.go
@@ -48,6 +48,29 @@ func (s Service) Add(domain, path, url string) error {
 	return nil
 }
 
+// Update modifies an existing short entry and changes where it points to
+func (s Service) Update(domain, path, url string) error {
+	body := s.Body(domain, path, url)
+	req, err := s.Request(http.MethodPut, body)
+	if err != nil {
+		return fmt.Errorf("Failed building request: %s", err.Error())
+	}
+	res, err := s.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 200 {
+		return &shortenError{
+			fmt.Sprintf(
+				"Unexpected status, expected 200, received %d",
+				res.StatusCode,
+			),
+			res.StatusCode,
+		}
+	}
+	return nil
+}
+
 // Body renders the Request's body
 func (s Service) Body(domain, path, url string) (out io.Reader) {
 	message := make(map[string]string)

--- a/mcc/short/short/short.go
+++ b/mcc/short/short/short.go
@@ -1,0 +1,95 @@
+package short
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func NewService() *Service {
+	return &Service{}
+}
+
+type Service struct {
+	aPIKey            string
+	AddURL, UpdateURL string
+}
+
+func (s *Service) SetAPIKey(key string) *Service {
+	s.aPIKey = key
+	return s
+}
+
+// Add an entry to the shortener with handle path and destination url
+func (s Service) Add(domain, path, url string) error {
+	body := s.Body(domain, path, url)
+	req, err := s.Request(http.MethodPost, body)
+	if err != nil {
+		return err
+	}
+	res, err := s.Do(req)
+	if err != nil {
+		return err
+	}
+	if res.StatusCode != 201 {
+		return &shortenError{
+			fmt.Sprintf(
+				"Unexpected status, expected 201, received %d",
+				res.StatusCode,
+			),
+			res.StatusCode,
+		}
+	}
+	return nil
+}
+
+// Body renders the Request's body
+func (s Service) Body(domain, path, url string) (out io.Reader) {
+	message := make(map[string]string)
+	message["path"] = path
+	message["originalURL"] = url
+	message["domain"] = domain
+
+	buf, err := json.Marshal(message)
+	if err != nil {
+		return
+	}
+	out = bytes.NewBuffer(buf)
+	return
+}
+
+// Request to add entry
+func (s Service) Request(method string, body io.Reader) (req *http.Request, err error) {
+	req, err = http.NewRequest(method, s.AddURL, body)
+	if err != nil {
+		return
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Authorization", s.aPIKey)
+	return
+}
+
+// Do executes the request to add an entry
+func (s Service) Do(req *http.Request) (res *http.Response, err error) {
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		err = fmt.Errorf("Failed executing request: %s", err.Error())
+		return
+	}
+	return
+}
+
+type shortenError struct {
+	s    string
+	code int
+}
+
+func (e *shortenError) Error() string {
+	return e.s
+}
+
+func (e *shortenError) ErrorCode() int {
+	return e.code
+}

--- a/mcc/short/short/short.go
+++ b/mcc/short/short/short.go
@@ -36,7 +36,7 @@ func (s Service) Add(domain, path, url string) error {
 	if err != nil {
 		return err
 	}
-	if res.StatusCode != 201 {
+	if res.StatusCode != 200 {
 		return &shortenError{
 			fmt.Sprintf(
 				"Unexpected status, expected 201, received %d",

--- a/mcc/short/short/short.go
+++ b/mcc/short/short/short.go
@@ -28,7 +28,7 @@ func (s *Service) SetAPIKey(key string) *Service {
 // Add an entry to the shortener with handle path and destination url
 func (s Service) Add(domain, path, url string) error {
 	body := s.Body(domain, path, url)
-	req, err := s.Request(http.MethodPost, body)
+	req, err := s.Request(http.MethodPost, s.AddURL, body)
 	if err != nil {
 		return err
 	}
@@ -51,7 +51,7 @@ func (s Service) Add(domain, path, url string) error {
 // Update modifies an existing short entry and changes where it points to
 func (s Service) Update(domain, path, url string) error {
 	body := s.Body(domain, path, url)
-	req, err := s.Request(http.MethodPut, body)
+	req, err := s.Request(http.MethodPut, s.UpdateURL, body)
 	if err != nil {
 		return fmt.Errorf("Failed building request: %s", err.Error())
 	}
@@ -87,8 +87,8 @@ func (s Service) Body(domain, path, url string) (out io.Reader) {
 }
 
 // Request to Service
-func (s Service) Request(method string, body io.Reader) (req *http.Request, err error) {
-	req, err = http.NewRequest(method, s.AddURL, body)
+func (s Service) Request(method, endpoint string, body io.Reader) (req *http.Request, err error) {
+	req, err = http.NewRequest(method, endpoint, body)
 	if err != nil {
 		return
 	}

--- a/mcc/short/short/short_test.go
+++ b/mcc/short/short/short_test.go
@@ -1,0 +1,202 @@
+package short
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func ExampleServiceAdd() {
+	service := NewService().SetAPIKey("my-api-key")
+	service.AddURL = "https://example.com/shortener/add"
+	err := service.Add("xample.cm", "this", "https://example.com/very/long/url")
+	if err != nil {
+		// Handle error
+	}
+}
+
+func TestAddShortEntry(t *testing.T) {
+	data := []struct {
+		domain, originalURL, path, title string
+		tags                             []string
+		status                           int
+	}{
+		{
+			domain:      "shrt.co",
+			originalURL: "http://yourlongdomain.com/yourlonglink",
+			path:        "correct",
+			title:       "Some url title",
+			tags: []string{
+				"tag1",
+				"tag2",
+			},
+			status: http.StatusCreated,
+		},
+		{
+			domain:      "shrt.co",
+			originalURL: "http://yourlongdomain.com/yourlonglink",
+			path:        "duplicated",
+			title:       "Some url title",
+			tags: []string{
+				"tag1",
+				"tag2",
+			},
+			status: 409,
+		},
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(
+		w http.ResponseWriter,
+		r *http.Request,
+	) {
+		// Process body
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Error()
+		}
+		s := make(map[string]string)
+		err = json.Unmarshal(body, &s)
+		if err != nil {
+			t.Error()
+		}
+		for _, d := range data {
+			if d.path == s["path"] {
+				w.Header().Set(
+					"Content-Type",
+					"application/json",
+				)
+				w.WriteHeader(d.status)
+				fmt.Fprintln(w, "")
+			}
+		}
+	}))
+	defer server.Close()
+
+	service := NewService()
+	service.AddURL = server.URL
+	for _, tt := range data {
+		err := service.Add(tt.domain, tt.path, tt.originalURL)
+		if err != nil {
+			if e, ok := err.(*shortenError); !ok {
+				t.Error(err)
+			} else {
+				if e.ErrorCode() != tt.status {
+					t.Errorf(
+						"Unexpected response status, expected %d but received %d",
+						tt.status,
+						e.ErrorCode(),
+					)
+				}
+			}
+		}
+	}
+}
+
+func TestAddShortEntryReq(t *testing.T) {
+	data := []struct {
+		domain, path, url   string
+		apikey, contentType string
+		apiPass             bool
+	}{
+		{
+			domain:      "dvx.cm",
+			path:        "correct",
+			url:         "",
+			contentType: "application/json",
+			apikey:      "your-api-key",
+			apiPass:     true,
+		},
+		{
+			domain:      "example.com",
+			path:        "correct",
+			url:         "",
+			contentType: "application/json",
+			apikey:      "your-api-key",
+			apiPass:     true,
+		},
+		{
+			domain:      "dvx.cm",
+			path:        "noAPIKey",
+			url:         "",
+			contentType: "application/json",
+			apikey:      "",
+			apiPass:     false,
+		},
+		{
+			domain:      "dvx.cm",
+			path:        "wrongAPIKey",
+			url:         "",
+			contentType: "application/json",
+			apikey:      "this-is-not-an-api-key",
+			apiPass:     false,
+		},
+	}
+
+	for _, tt := range data {
+		service := NewService().
+			SetAPIKey(tt.apikey)
+
+		bod := service.Body(tt.domain, tt.path, tt.url)
+		r, err := service.Request(http.MethodPost, bod)
+		if err != nil {
+			t.Error(err)
+		}
+
+		// Verify request headers
+		t.Run("Content-Type", func(t *testing.T) {
+			if r.Header.Get("Content-Type") != tt.contentType {
+				t.Errorf("Content-Type equals %s", r.Header.Get("Content-Type"))
+			}
+		})
+		t.Run("Authorization", func(t *testing.T) {
+			if r.Header.Get("Authorization") != tt.apikey && tt.apiPass {
+				t.Errorf(
+					"Wrong API key, expected %s got %s",
+					tt.apikey,
+					r.Header.Get("Authorization"),
+				)
+			}
+		})
+
+		// Verify request body
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Error()
+		}
+		s := make(map[string]string)
+		err = json.Unmarshal(body, &s)
+		if err != nil {
+			t.Error()
+		}
+		t.Run("Domain field", func(t *testing.T) {
+			if s["domain"] != tt.domain {
+				t.Errorf(
+					"Expected domain %s, got %s",
+					tt.domain,
+					s["domain"],
+				)
+			}
+		})
+		t.Run("Path field", func(t *testing.T) {
+			if s["path"] != tt.path {
+				t.Errorf(
+					"Expected path %s, got %s",
+					tt.path,
+					s["path"],
+				)
+			}
+		})
+		t.Run("URL field", func(t *testing.T) {
+			if s["originalURL"] != tt.url {
+				t.Errorf(
+					"Expected originalURL %s, got %s",
+					tt.url,
+					s["originalURL"],
+				)
+			}
+		})
+	}
+}

--- a/mcc/short/short/short_test.go
+++ b/mcc/short/short/short_test.go
@@ -150,7 +150,7 @@ func TestAddShortEntryReq(t *testing.T) {
 			SetAPIKey(tt.apikey)
 
 		bod := service.Body(tt.domain, tt.path, tt.url)
-		r, err := service.Request(http.MethodPost, bod)
+		r, err := service.Request(http.MethodPost, service.AddURL, bod)
 		if err != nil {
 			t.Error(err)
 		}

--- a/mcc/short/short/short_test.go
+++ b/mcc/short/short/short_test.go
@@ -42,7 +42,8 @@ func TestAddShortEntry(t *testing.T) {
 				"tag1",
 				"tag2",
 			},
-			status: http.StatusCreated,
+			status: http.StatusOK, // API docs are wrong,
+			// it retugrns a 200
 		},
 		{
 			domain:      "shrt.co",


### PR DESCRIPTION
We want to be able to create shortened URLs as part of some operations, so creating a new tool for  it (temporarily called short, until we find a better name). 

This tool is using the short.cm API specification, mostly as detailed in http://docs.shortcm.apiary.io/# . This documentation is wrong, so I haven't been able to make the Update client actually work (returns a 404 error), so I didn't add the client here even though the functions and tests are present, as specified in the documentation.

The API is as generic as possible, so it should be abstractable to use other shortening service providers in the future.

**Add shortener client**
Implement the backend for a shortener service client based on
short.cm's API. Use only the Add method and its tests.

**Improve documentation/comments**

**Add Update API call to shortener**
Adds the function to call the Update API of short.cm.

**Fix return codes for short.cm**
The API documentation does not agree with the real usage. This change
reflects current behaviour.

**Add add command**
Create the basic infrastructure for the CLI and add the "add" command
to create new shortened URLs.
