### PR TITLE
Make delete to wait for instance to be deleted

### DIFF
--- a/mcc/odin/odin/instance_clone.go
+++ b/mcc/odin/odin/instance_clone.go
@@ -33,7 +33,7 @@ func CloneInstance(
 	if err != nil {
 		return
 	}
-	err = WaitForInstance(instance, svc)
+	err = WaitForInstance(instance, svc, "available")
 	if err != nil {
 		return
 	}

--- a/mcc/odin/odin/instance_create.go
+++ b/mcc/odin/odin/instance_create.go
@@ -73,7 +73,7 @@ func CreateInstance(
 	if err != nil {
 		return
 	}
-	err = WaitForInstance(instance, svc)
+	err = WaitForInstance(instance, svc, "available")
 	if err != nil {
 		return
 	}

--- a/mcc/odin/odin/instance_delete.go
+++ b/mcc/odin/odin/instance_delete.go
@@ -11,10 +11,14 @@ func DeleteInstance(
 	identifier string,
 	svc rdsiface.RDSAPI,
 ) error {
-	_, err := svc.DeleteDBInstance(
+	out, err := svc.DeleteDBInstance(
 		&rds.DeleteDBInstanceInput{
 			DBInstanceIdentifier: aws.String(identifier),
 		},
 	)
+	if err != nil {
+		return err
+	}
+	err = WaitForInstance(out.DBInstance, svc, "deleted")
 	return err
 }

--- a/mcc/odin/odin/instance_restore.go
+++ b/mcc/odin/odin/instance_restore.go
@@ -76,7 +76,7 @@ func RestoreInstance(
 	if err != nil {
 		return
 	}
-	err = WaitForInstance(instance, svc)
+	err = WaitForInstance(instance, svc, "available")
 	if err != nil {
 		return
 	}

--- a/mcc/odin/odin/odin.go
+++ b/mcc/odin/odin/odin.go
@@ -70,9 +70,10 @@ func GetLastSnapshot(
 func WaitForInstance(
 	instance *rds.DBInstance,
 	svc rdsiface.RDSAPI,
+	status string,
 ) (err error) {
 	var res *rds.DescribeDBInstancesOutput
-	for *instance.DBInstanceStatus != "available" {
+	for *instance.DBInstanceStatus != status {
 		id := instance.DBInstanceIdentifier
 		res, err = svc.DescribeDBInstances(
 			&rds.DescribeDBInstancesInput{


### PR DESCRIPTION
This PR is a little bit big, sorry about that.
Also, the implementation of mockRDSClient could probably be better... but it might imply major refactoring of the tests for all operations. I think this might be better done separately, once the whole `instance delete` features are finished.
These features left are:
* When the instance does not exist.
* When the delete operation has been requested to not include final snapshot.