### PR TITLE
Add final snapshot choice to DeleteInstance

### DIFF
--- a/mcc/odin/odin/instance_create_test.go
+++ b/mcc/odin/odin/instance_create_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/rds"
-
 	"github.com/poka-yoke/spaceflight/mcc/odin/odin"
 )
 
@@ -17,7 +15,6 @@ type createInstanceCase struct {
 	password     string
 	user         string
 	size         int64
-	instances    []*rds.DBInstance
 }
 
 var createInstanceCases = []createInstanceCase{

--- a/mcc/odin/odin/instance_delete.go
+++ b/mcc/odin/odin/instance_delete.go
@@ -1,8 +1,6 @@
 package odin
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
@@ -11,17 +9,19 @@ import (
 // DeleteInstance deletes an existing RDS database instance.
 func DeleteInstance(
 	identifier string,
+	snapshotID string,
 	svc rdsiface.RDSAPI,
 ) error {
-	snapshotID := fmt.Sprintf(
-		"%s-final",
-		identifier,
-	)
+	params := &rds.DeleteDBInstanceInput{
+		DBInstanceIdentifier: aws.String(identifier),
+	}
+	if snapshotID == "" {
+		params.SkipFinalSnapshot = aws.Bool(true)
+	} else {
+		params.FinalDBSnapshotIdentifier = aws.String(snapshotID)
+	}
 	out, err := svc.DeleteDBInstance(
-		&rds.DeleteDBInstanceInput{
-			DBInstanceIdentifier:      aws.String(identifier),
-			FinalDBSnapshotIdentifier: aws.String(snapshotID),
-		},
+		params,
 	)
 	if err != nil {
 		return err

--- a/mcc/odin/odin/instance_delete.go
+++ b/mcc/odin/odin/instance_delete.go
@@ -1,6 +1,8 @@
 package odin
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
@@ -11,9 +13,14 @@ func DeleteInstance(
 	identifier string,
 	svc rdsiface.RDSAPI,
 ) error {
+	snapshotID := fmt.Sprintf(
+		"%s-final",
+		identifier,
+	)
 	out, err := svc.DeleteDBInstance(
 		&rds.DeleteDBInstanceInput{
-			DBInstanceIdentifier: aws.String(identifier),
+			DBInstanceIdentifier:      aws.String(identifier),
+			FinalDBSnapshotIdentifier: aws.String(snapshotID),
 		},
 	)
 	if err != nil {

--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -82,6 +82,7 @@ func (m mockRDSClient) FindInstance(id string) (
 			instance = obj
 			index = i
 			found = true
+			break
 		}
 	}
 	if !found {

--- a/mcc/odin/odin/mock_rds_client_test.go
+++ b/mcc/odin/odin/mock_rds_client_test.go
@@ -69,6 +69,56 @@ func (m *mockRDSClient) DeleteDBInstance(
 	return
 }
 
+// FindSnapshotInstance return index and snapshot in mockRDSClient.dbSnapshots
+// for a specific instance id.
+func (m mockRDSClient) FindSnapshotInstance(instanceID string) (
+	index int,
+	snapshot *rds.DBSnapshot,
+	err error,
+) {
+	found := false
+	for i, obj := range m.dbSnapshots {
+		if *obj.DBInstanceIdentifier == instanceID {
+			snapshot = obj
+			index = i
+			found = true
+			break
+		}
+	}
+	if !found {
+		err = fmt.Errorf(
+			"No snapshot for instance %s",
+			instanceID,
+		)
+	}
+	return
+}
+
+// FindSnapshot return index and snapshot in mockRDSClient.dbSnapshots
+// for a specific id.
+func (m mockRDSClient) FindSnapshot(id string) (
+	index int,
+	snapshot *rds.DBSnapshot,
+	err error,
+) {
+	found := false
+	for i, obj := range m.dbSnapshots {
+		if *obj.DBSnapshotIdentifier == id {
+			snapshot = obj
+			index = i
+			found = true
+			break
+		}
+	}
+	if !found {
+		err = fmt.Errorf(
+			"No such snapshot %s",
+			id,
+		)
+	}
+	return
+}
+
 // FindInstance return index and instance in mockRDSClient.dbInstances
 // for a specific id.
 func (m mockRDSClient) FindInstance(id string) (


### PR DESCRIPTION
This PR completes the instance deletion implementation, by adding an argument to specify the final snapshot name. If it's an empty string, no final snapshot is taken.

It also improves the loop to find instances in the mock, by breaking the loop when the instance was found. Same behaviour have been implemented to find snapshot by snapshot ID, and by instance ID.

About the doubt on the trimming of the last character of a string, it have been postponed to another PR.

cc @miguelbernadi 