### PR TITLE
Refactor odin

### DIFF
--- a/cmd/odin/cmd/instance_clone.go
+++ b/cmd/odin/cmd/instance_clone.go
@@ -23,6 +23,7 @@ var instanceCloneCmd = &cobra.Command{
 		}
 		svc := odin.Init()
 		params := odin.Instance{
+			Identifier:           args[0],
 			Type:                 instanceType,
 			User:                 user,
 			Password:             password,
@@ -32,7 +33,6 @@ var instanceCloneCmd = &cobra.Command{
 			OriginalInstanceName: from,
 		}
 		endpoint, err := odin.CloneInstance(
-			args[0],
 			params,
 			svc,
 		)

--- a/cmd/odin/cmd/instance_clone.go
+++ b/cmd/odin/cmd/instance_clone.go
@@ -22,6 +22,9 @@ var instanceCloneCmd = &cobra.Command{
 			log.Fatal(NewInstanceIDReq)
 		}
 		svc := odin.Init()
+		if from == "" {
+			log.Fatal("Original instance name not provided")
+		}
 		params := odin.Instance{
 			Identifier:           args[0],
 			Type:                 instanceType,

--- a/cmd/odin/cmd/instance_clone.go
+++ b/cmd/odin/cmd/instance_clone.go
@@ -22,16 +22,13 @@ var instanceCloneCmd = &cobra.Command{
 			log.Fatal(NewInstanceIDReq)
 		}
 		svc := odin.Init()
-		createParams := odin.CreateParams{
-			InstanceType:    instanceType,
-			User:            user,
-			Password:        password,
-			SubnetGroupName: subnetName,
-			SecurityGroups:  strings.Split(securityGroups, ","),
-			Size:            size,
-		}
-		params := odin.CloneParams{
-			CreateParams:         createParams,
+		params := odin.Instance{
+			Type:                 instanceType,
+			User:                 user,
+			Password:             password,
+			SubnetGroupName:      subnetName,
+			SecurityGroups:       strings.Split(securityGroups, ","),
+			Size:                 size,
 			OriginalInstanceName: from,
 		}
 		endpoint, err := odin.CloneInstance(

--- a/cmd/odin/cmd/instance_create.go
+++ b/cmd/odin/cmd/instance_create.go
@@ -23,8 +23,8 @@ var instanceCreateCmd = &cobra.Command{
 			log.Fatal(NewInstanceIDReq)
 		}
 		svc := odin.Init()
-		params := odin.CreateParams{
-			InstanceType:    instanceType,
+		params := odin.Instance{
+			Type:            instanceType,
 			User:            user,
 			Password:        password,
 			SubnetGroupName: subnetName,

--- a/cmd/odin/cmd/instance_create.go
+++ b/cmd/odin/cmd/instance_create.go
@@ -24,6 +24,7 @@ var instanceCreateCmd = &cobra.Command{
 		}
 		svc := odin.Init()
 		params := odin.Instance{
+			Identifier:      args[0],
 			Type:            instanceType,
 			User:            user,
 			Password:        password,
@@ -32,7 +33,6 @@ var instanceCreateCmd = &cobra.Command{
 			Size:            size,
 		}
 		endpoint, err := odin.CreateInstance(
-			args[0],
 			params,
 			svc,
 		)

--- a/cmd/odin/cmd/instance_delete.go
+++ b/cmd/odin/cmd/instance_delete.go
@@ -24,7 +24,7 @@ var instanceDeleteCmd = &cobra.Command{
 
 		err := odin.DeleteInstance(
 			odin.Instance{
-				Identifier: args[0],
+				Identifier:      args[0],
 				FinalSnapshotID: finalSnapshotID,
 			},
 			svc,

--- a/cmd/odin/cmd/instance_delete.go
+++ b/cmd/odin/cmd/instance_delete.go
@@ -21,9 +21,12 @@ var instanceDeleteCmd = &cobra.Command{
 			log.Fatal(InstanceIDReq)
 		}
 		svc := odin.Init()
+
 		err := odin.DeleteInstance(
-			args[0],
-			finalSnapshotID,
+			odin.Instance{
+				Identifier: args[0],
+				FinalSnapshotID: finalSnapshotID,
+			},
 			svc,
 		)
 		if err != nil {

--- a/cmd/odin/cmd/instance_restore.go
+++ b/cmd/odin/cmd/instance_restore.go
@@ -21,8 +21,8 @@ var instanceRestoreCmd = &cobra.Command{
 		}
 		svc := odin.Init()
 		securityGroupsList := strings.Split(securityGroups, ",")
-		params := odin.RestoreParams{
-			InstanceType:         instanceType,
+		params := odin.Instance{
+			Type:                 instanceType,
 			SubnetGroupName:      subnetName,
 			SecurityGroups:       securityGroupsList,
 			OriginalInstanceName: from,

--- a/cmd/odin/cmd/instance_restore.go
+++ b/cmd/odin/cmd/instance_restore.go
@@ -22,13 +22,13 @@ var instanceRestoreCmd = &cobra.Command{
 		svc := odin.Init()
 		securityGroupsList := strings.Split(securityGroups, ",")
 		params := odin.Instance{
+			Identifier:           args[0],
 			Type:                 instanceType,
 			SubnetGroupName:      subnetName,
 			SecurityGroups:       securityGroupsList,
 			OriginalInstanceName: from,
 		}
 		endpoint, err := odin.RestoreInstance(
-			args[0],
 			params,
 			svc,
 		)

--- a/cmd/odin/cmd/instance_scale.go
+++ b/cmd/odin/cmd/instance_scale.go
@@ -24,7 +24,7 @@ var instanceScaleCmd = &cobra.Command{
 		svc := odin.Init()
 		params := odin.Instance{
 			Identifier: args[0],
-			Type: instanceType,
+			Type:       instanceType,
 		}
 		result, err := odin.ScaleInstance(
 			params,

--- a/cmd/odin/cmd/instance_scale.go
+++ b/cmd/odin/cmd/instance_scale.go
@@ -22,9 +22,12 @@ var instanceScaleCmd = &cobra.Command{
 			log.Fatal(InstanceIDReq)
 		}
 		svc := odin.Init()
+		params := odin.Instance{
+			Identifier: args[0],
+			Type: instanceType,
+		}
 		result, err := odin.ScaleInstance(
-			args[0],
-			instanceType,
+			params,
 			delay,
 			svc,
 		)

--- a/pkg/odin/instance.go
+++ b/pkg/odin/instance.go
@@ -81,15 +81,23 @@ func (i Instance) CreateDBInput(
 func (i Instance) ModifyDBInput(
 	identifier string,
 	svc rdsiface.RDSAPI,
-) *rds.ModifyDBInstanceInput {
+) (result *rds.ModifyDBInstanceInput, err error) {
 	SecurityGroups := []*string{}
 	for _, sgid := range i.SecurityGroups {
 		SecurityGroups = append(SecurityGroups, aws.String(sgid))
 	}
-	return &rds.ModifyDBInstanceInput{
+	result = &rds.ModifyDBInstanceInput{
 		DBInstanceIdentifier: &identifier,
 		VpcSecurityGroupIds:  SecurityGroups,
 	}
+	if err = result.Validate(); err != nil {
+		err = fmt.Errorf(
+			"DB instance parameters failed to validate: %s",
+			err,
+		)
+		return nil, err
+	}
+	return result, nil
 }
 
 // RestoreDBInput returns RestoreDBInstanceFromDBSnapshotInput for the

--- a/pkg/odin/instance.go
+++ b/pkg/odin/instance.go
@@ -31,7 +31,7 @@ func (i Instance) CloneDBInput(
 	result *rds.CreateDBInstanceInput,
 	err error,
 ) {
-	instance, err := i.AddLastSnapshot(i.OriginalInstanceName, svc)
+	instance, err := i.addLastSnapshot(svc)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (i Instance) RestoreDBInput(
 		err = fmt.Errorf("Original Instance Name was empty")
 		return nil, err
 	}
-	instance, err := i.AddLastSnapshot(i.OriginalInstanceName, svc)
+	instance, err := i.addLastSnapshot(svc)
 	if err != nil {
 		return nil, err
 	}
@@ -120,17 +120,16 @@ func (i Instance) RestoreDBInput(
 	return out, nil
 }
 
-// AddLastSnapshot adds the reference to the last available snapshot
+// addLastSnapshot adds the reference to the last available snapshot
 // of the target instance to this instance.
-func (i *Instance) AddLastSnapshot(
-	identifier string,
+func (i *Instance) addLastSnapshot(
 	svc rdsiface.RDSAPI,
 ) (_ *Instance, err error) {
-	i.LastSnapshot, err = GetLastSnapshot(identifier, svc)
+	i.LastSnapshot, err = GetLastSnapshot(i.OriginalInstanceName, svc)
 	if err != nil {
 		err = fmt.Errorf(
 			"No snapshot found for %s instance",
-			identifier,
+			i.OriginalInstanceName,
 		)
 		return i, err
 	}

--- a/pkg/odin/instance.go
+++ b/pkg/odin/instance.go
@@ -66,11 +66,7 @@ func (i Instance) CreateDBInput(
 		result.AllocatedStorage = i.LastSnapshot.AllocatedStorage
 		result.MasterUsername = i.LastSnapshot.MasterUsername
 	}
-	if err = result.Validate(); err != nil {
-		err = fmt.Errorf(
-			"DB instance parameters failed to validate: %s",
-			err,
-		)
+	if err = validate(result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -88,11 +84,7 @@ func (i Instance) DeleteDBInput(
 	} else {
 		result.FinalDBSnapshotIdentifier = &i.FinalSnapshotID
 	}
-	if err = result.Validate(); err != nil {
-		err = fmt.Errorf(
-			"DB instance parameters failed to validate: %s",
-			err,
-		)
+	if err = validate(result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -113,11 +105,7 @@ func (i Instance) ModifyDBInput(
 		VpcSecurityGroupIds:  SecurityGroups,
 		ApplyImmediately:     aws.Bool(applyNow),
 	}
-	if err = result.Validate(); err != nil {
-		err = fmt.Errorf(
-			"DB instance parameters failed to validate: %s",
-			err,
-		)
+	if err = validate(result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -147,11 +135,7 @@ func (i Instance) RestoreDBInput(
 		DBSubnetGroupName:    &i.SubnetGroupName,
 		Engine:               aws.String("postgres"),
 	}
-	if err = result.Validate(); err != nil {
-		err = fmt.Errorf(
-			"DB instance parameters failed to validate: %s",
-			err,
-		)
+	if err = validate(result); err != nil {
 		return nil, err
 	}
 	return result, nil
@@ -171,4 +155,21 @@ func (i *Instance) addLastSnapshot(
 		return i, err
 	}
 	return i, nil
+}
+
+// Validator interface enforces validation of objects through
+// Validate() method
+type Validator interface {
+	Validate() error
+}
+
+func validate(result Validator) error {
+	if err := result.Validate(); err != nil {
+		err = fmt.Errorf(
+			"DB instance parameters failed to validate: %s",
+			err,
+		)
+		return err
+	}
+	return nil
 }

--- a/pkg/odin/instance.go
+++ b/pkg/odin/instance.go
@@ -22,6 +22,23 @@ type Instance struct {
 	LastSnapshot         *rds.DBSnapshot
 }
 
+// CloneDBInput returns CreateDBInstanceInput for the instance with
+// Snapshot belonging to a target instance.
+func (i Instance) CloneDBInput(
+	identifier string,
+	svc rdsiface.RDSAPI,
+) (
+	result *rds.CreateDBInstanceInput,
+	err error,
+) {
+	instance, err := i.AddLastSnapshot(i.OriginalInstanceName, svc)
+	if err != nil {
+		return nil, err
+	}
+	i = *instance
+	return i.CreateDBInput(identifier, svc)
+}
+
 // CreateDBInput returns CreateDBInstanceInput for the instance.
 func (i Instance) CreateDBInput(
 	identifier string,

--- a/pkg/odin/instance.go
+++ b/pkg/odin/instance.go
@@ -98,7 +98,7 @@ func (i Instance) RestoreDBInput(
 	identifier string,
 	svc rdsiface.RDSAPI,
 ) (
-	out *rds.RestoreDBInstanceFromDBSnapshotInput,
+	result *rds.RestoreDBInstanceFromDBSnapshotInput,
 	err error,
 ) {
 	if i.OriginalInstanceName == "" {
@@ -110,14 +110,21 @@ func (i Instance) RestoreDBInput(
 		return nil, err
 	}
 	i = *instance
-	out = &rds.RestoreDBInstanceFromDBSnapshotInput{
+	result = &rds.RestoreDBInstanceFromDBSnapshotInput{
 		DBInstanceClass:      &i.Type,
 		DBInstanceIdentifier: &identifier,
 		DBSnapshotIdentifier: i.LastSnapshot.DBSnapshotIdentifier,
 		DBSubnetGroupName:    &i.SubnetGroupName,
 		Engine:               aws.String("postgres"),
 	}
-	return out, nil
+	if err = result.Validate(); err != nil {
+		err = fmt.Errorf(
+			"DB instance parameters failed to validate: %s",
+			err,
+		)
+		return nil, err
+	}
+	return result, nil
 }
 
 // addLastSnapshot adds the reference to the last available snapshot

--- a/pkg/odin/instance.go
+++ b/pkg/odin/instance.go
@@ -21,7 +21,7 @@ type Instance struct {
 	Size                 int64
 	OriginalInstanceName string
 	LastSnapshot         *rds.DBSnapshot
-	FinalSnapshotID string
+	FinalSnapshotID      string
 }
 
 // CloneDBInput returns CreateDBInstanceInput for the instance with
@@ -79,7 +79,7 @@ func (i Instance) CreateDBInput(
 // DeleteDBInput returns DeleteDBInstanceInput for the instance.
 func (i Instance) DeleteDBInput(
 	svc rdsiface.RDSAPI,
-)(result *rds.DeleteDBInstanceInput, err error) {
+) (result *rds.DeleteDBInstanceInput, err error) {
 	result = &rds.DeleteDBInstanceInput{
 		DBInstanceIdentifier: aws.String(i.Identifier),
 	}
@@ -109,9 +109,9 @@ func (i Instance) ModifyDBInput(
 	}
 	result = &rds.ModifyDBInstanceInput{
 		DBInstanceIdentifier: &i.Identifier,
-		DBInstanceClass: &i.Type,
+		DBInstanceClass:      &i.Type,
 		VpcSecurityGroupIds:  SecurityGroups,
-		ApplyImmediately: aws.Bool(applyNow),
+		ApplyImmediately:     aws.Bool(applyNow),
 	}
 	if err = result.Validate(); err != nil {
 		err = fmt.Errorf(

--- a/pkg/odin/instance.go
+++ b/pkg/odin/instance.go
@@ -1,0 +1,131 @@
+package odin
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
+)
+
+// Instance holds parameters needed for any operations related to
+// instances and provides methods to obtain the AWS structures needed
+// to perform them.
+type Instance struct {
+	Type                 string
+	User                 string
+	Password             string
+	SubnetGroupName      string
+	SecurityGroups       []string
+	Size                 int64
+	OriginalInstanceName string
+	LastSnapshot         *rds.DBSnapshot
+}
+
+// CreateDBInput method creates a new CreateDBInstanceInput from
+// rds.DBSnapshot.
+func (params Instance) CreateDBInput(
+	identifier string,
+	svc rdsiface.RDSAPI,
+) (result *rds.CreateDBInstanceInput, err error) {
+	result = &rds.CreateDBInstanceInput{
+		AllocatedStorage:     &params.Size,
+		DBInstanceIdentifier: &identifier,
+		DBSubnetGroupName:    &params.SubnetGroupName,
+		DBInstanceClass:      &params.Type,
+		DBSecurityGroups: []*string{
+			aws.String("default"),
+		},
+		Engine:             aws.String("postgres"),
+		EngineVersion:      aws.String("9.4.11"),
+		MasterUsername:     &params.User,
+		MasterUserPassword: &params.Password,
+		Tags: []*rds.Tag{
+			{
+				Key:   aws.String("Name"),
+				Value: &identifier,
+			},
+		},
+	}
+	if params.LastSnapshot != nil {
+		result.AllocatedStorage = params.LastSnapshot.AllocatedStorage
+		result.MasterUsername = params.LastSnapshot.MasterUsername
+	}
+	if err = result.Validate(); err != nil {
+		err = fmt.Errorf(
+			"DB instance parameters failed to validate: %s",
+			err,
+		)
+		return nil, err
+	}
+	return result, nil
+}
+
+// ModifyDBInput method creates a new ModifyDBInstanceInput
+// rds.DBSnapshot.
+func (params Instance) ModifyDBInput(
+	identifier string,
+	svc rdsiface.RDSAPI,
+) *rds.ModifyDBInstanceInput {
+	SecurityGroups := []*string{}
+	for _, sgid := range params.SecurityGroups {
+		SecurityGroups = append(SecurityGroups, aws.String(sgid))
+	}
+	return &rds.ModifyDBInstanceInput{
+		DBInstanceIdentifier: &identifier,
+		VpcSecurityGroupIds:  SecurityGroups,
+	}
+}
+
+// RestoreDBInput method creates a new
+// RestoreDBInstanceFromDBSnapshotInput from provided CreateDBParams and
+// rds.DBSnapshot.
+func (p Instance) RestoreDBInput(
+	identifier string,
+	svc rdsiface.RDSAPI,
+) (
+	out *rds.RestoreDBInstanceFromDBSnapshotInput,
+	err error,
+) {
+	if p.OriginalInstanceName == "" {
+		err = fmt.Errorf("Original Instance Name was empty")
+		return
+	}
+	snapshot, err := GetLastSnapshot(p.OriginalInstanceName, svc)
+	if err != nil {
+		err = fmt.Errorf(
+			"No snapshot found for %s instance",
+			p.OriginalInstanceName,
+		)
+		return
+	}
+	out = &rds.RestoreDBInstanceFromDBSnapshotInput{
+		DBInstanceClass:      &p.Type,
+		DBInstanceIdentifier: &identifier,
+		DBSnapshotIdentifier: snapshot.DBSnapshotIdentifier,
+		DBSubnetGroupName:    &p.SubnetGroupName,
+		Engine:               aws.String("postgres"),
+	}
+	return
+}
+
+// AddLastSnapshot adds the reference to the last available snapshot
+// to the Instance structure, when it represents an already existing
+// RDS instance.
+func (params *Instance) AddLastSnapshot(
+	identifier string,
+	svc rdsiface.RDSAPI,
+) (
+	self *Instance,
+	err error,
+) {
+	params.LastSnapshot, err = GetLastSnapshot(identifier, svc)
+	if err != nil {
+		err = fmt.Errorf(
+			"No snapshot found for %s instance",
+			identifier,
+		)
+		return params, err
+	}
+	return params, nil
+}

--- a/pkg/odin/instance.go
+++ b/pkg/odin/instance.go
@@ -100,6 +100,7 @@ func (i Instance) DeleteDBInput(
 
 // ModifyDBInput returns ModifyDBInstanceInput for the instance.
 func (i Instance) ModifyDBInput(
+	applyNow bool,
 	svc rdsiface.RDSAPI,
 ) (result *rds.ModifyDBInstanceInput, err error) {
 	SecurityGroups := []*string{}
@@ -108,7 +109,9 @@ func (i Instance) ModifyDBInput(
 	}
 	result = &rds.ModifyDBInstanceInput{
 		DBInstanceIdentifier: &i.Identifier,
+		DBInstanceClass: &i.Type,
 		VpcSecurityGroupIds:  SecurityGroups,
+		ApplyImmediately: aws.Bool(applyNow),
 	}
 	if err = result.Validate(); err != nil {
 		err = fmt.Errorf(

--- a/pkg/odin/instance_clone.go
+++ b/pkg/odin/instance_clone.go
@@ -10,7 +10,6 @@ import (
 // from a snapshot. If a vpcid is specified the security group will be
 // in that VPC.
 func CloneInstance(
-	instanceName string,
 	params Instance,
 	svc rdsiface.RDSAPI,
 ) (
@@ -35,6 +34,6 @@ func CloneInstance(
 		return
 	}
 	result = *res.DBInstance.Endpoint.Address
-	err = modifyInstance(instanceName, params, svc)
+	err = modifyInstance(params, svc)
 	return
 }

--- a/pkg/odin/instance_clone.go
+++ b/pkg/odin/instance_clone.go
@@ -1,8 +1,6 @@
 package odin
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
 
@@ -16,9 +14,6 @@ func CloneInstance(
 	result string,
 	err error,
 ) {
-	if params.OriginalInstanceName == "" {
-		return "", fmt.Errorf("Original instance name not provided")
-	}
 	rdsParams, err := params.CloneDBInput(
 		svc,
 	)

--- a/pkg/odin/instance_clone.go
+++ b/pkg/odin/instance_clone.go
@@ -43,11 +43,7 @@ func doClone(
 	instance *rds.DBInstance,
 	err error,
 ) {
-	pparams, err := params.AddLastSnapshot(params.OriginalInstanceName, svc)
-	if err != nil {
-		return nil, err
-	}
-	rdsParams, err := pparams.CreateDBInput(
+	rdsParams, err := params.CloneDBInput(
 		instanceName,
 		svc,
 	)
@@ -56,7 +52,7 @@ func doClone(
 	}
 	res, err := svc.CreateDBInstance(rdsParams)
 	if err != nil {
-		return
+		return nil, err
 	}
 	return res.DBInstance, nil
 }

--- a/pkg/odin/instance_clone_test.go
+++ b/pkg/odin/instance_clone_test.go
@@ -73,7 +73,6 @@ func TestCloneInstance(t *testing.T) {
 					OriginalInstanceName: test.from,
 				}
 				actual, err := odin.CloneInstance(
-					test.identifier,
 					params,
 					svc,
 				)

--- a/pkg/odin/instance_clone_test.go
+++ b/pkg/odin/instance_clone_test.go
@@ -65,6 +65,7 @@ func TestCloneInstance(t *testing.T) {
 					svc.AddSnapshots(test.snapshots)
 				}
 				params := odin.Instance{
+					Identifier: test.identifier,
 					Type:                 test.instanceType,
 					User:                 test.user,
 					Password:             test.password,

--- a/pkg/odin/instance_clone_test.go
+++ b/pkg/odin/instance_clone_test.go
@@ -64,14 +64,11 @@ func TestCloneInstance(t *testing.T) {
 				if test.from != "" {
 					svc.AddSnapshots(test.snapshots)
 				}
-				createParams := odin.CreateParams{
-					InstanceType: test.instanceType,
-					User:         test.user,
-					Password:     test.password,
-					Size:         test.size,
-				}
-				params := odin.CloneParams{
-					CreateParams:         createParams,
+				params := odin.Instance{
+					Type:                 test.instanceType,
+					User:                 test.user,
+					Password:             test.password,
+					Size:                 test.size,
 					OriginalInstanceName: test.from,
 				}
 				actual, err := odin.CloneInstance(

--- a/pkg/odin/instance_clone_test.go
+++ b/pkg/odin/instance_clone_test.go
@@ -65,7 +65,7 @@ func TestCloneInstance(t *testing.T) {
 					svc.AddSnapshots(test.snapshots)
 				}
 				params := odin.Instance{
-					Identifier: test.identifier,
+					Identifier:           test.identifier,
 					Type:                 test.instanceType,
 					User:                 test.user,
 					Password:             test.password,

--- a/pkg/odin/instance_create.go
+++ b/pkg/odin/instance_create.go
@@ -7,7 +7,6 @@ import (
 // CreateInstance creates a new RDS database instance. If a vpcid is
 // specified the security group will be in that VPC.
 func CreateInstance(
-	instanceName string,
 	params Instance,
 	svc rdsiface.RDSAPI,
 ) (result string, err error) {
@@ -26,6 +25,6 @@ func CreateInstance(
 		return
 	}
 	result = *res.DBInstance.Endpoint.Address
-	err = modifyInstance(instanceName, params, svc)
+	err = modifyInstance(params, svc)
 	return
 }

--- a/pkg/odin/instance_create.go
+++ b/pkg/odin/instance_create.go
@@ -1,71 +1,15 @@
 package odin
 
 import (
-	"fmt"
-
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
-
-// CreateParams represents CreateInstance parameters.
-type CreateParams struct {
-	InstanceType    string
-	User            string
-	Password        string
-	SubnetGroupName string
-	SecurityGroups  []string
-	Size            int64
-}
-
-// GetCreateDBInput method creates a new CreateDBInstanceInput from
-// provided CreateParams and rds.DBSnapshot.
-func (params CreateParams) GetCreateDBInput(
-	identifier string,
-	svc rdsiface.RDSAPI,
-) *rds.CreateDBInstanceInput {
-	return &rds.CreateDBInstanceInput{
-		AllocatedStorage:     &params.Size,
-		DBInstanceIdentifier: &identifier,
-		DBSubnetGroupName:    &params.SubnetGroupName,
-		DBInstanceClass:      &params.InstanceType,
-		DBSecurityGroups: []*string{
-			aws.String("default"),
-		},
-		Engine:             aws.String("postgres"),
-		EngineVersion:      aws.String("9.4.11"),
-		MasterUsername:     &params.User,
-		MasterUserPassword: &params.Password,
-		Tags: []*rds.Tag{
-			{
-				Key:   aws.String("Name"),
-				Value: &identifier,
-			},
-		},
-	}
-}
-
-// GetModifyDBInput method creates a new ModifyDBInstanceInput from
-// provided ModifyDBParams and rds.DBSnapshot.
-func (params CreateParams) GetModifyDBInput(
-	identifier string,
-	svc rdsiface.RDSAPI,
-) *rds.ModifyDBInstanceInput {
-	SecurityGroups := []*string{}
-	for _, sgid := range params.SecurityGroups {
-		SecurityGroups = append(SecurityGroups, aws.String(sgid))
-	}
-	return &rds.ModifyDBInstanceInput{
-		DBInstanceIdentifier: &identifier,
-		VpcSecurityGroupIds:  SecurityGroups,
-	}
-}
 
 // CreateInstance creates a new RDS database instance. If a vpcid is
 // specified the security group will be in that VPC.
 func CreateInstance(
 	instanceName string,
-	params CreateParams,
+	params Instance,
 	svc rdsiface.RDSAPI,
 ) (result string, err error) {
 	var instance *rds.DBInstance
@@ -84,22 +28,18 @@ func CreateInstance(
 
 func doCreate(
 	instanceName string,
-	params CreateParams,
+	params Instance,
 	svc rdsiface.RDSAPI,
 ) (
 	instance *rds.DBInstance,
 	err error,
 ) {
-	rdsParams := params.GetCreateDBInput(
+	rdsParams, err := params.CreateDBInput(
 		instanceName,
 		svc,
 	)
-	if err = rdsParams.Validate(); err != nil {
-		err = fmt.Errorf(
-			"DB instance parameters failed to validate: %s",
-			err,
-		)
-		return
+	if err != nil {
+		return nil, err
 	}
 	res, err := svc.CreateDBInstance(rdsParams)
 	if err != nil {

--- a/pkg/odin/instance_create_test.go
+++ b/pkg/odin/instance_create_test.go
@@ -105,10 +105,10 @@ func TestCreateInstance(t *testing.T) {
 			func(t *testing.T) {
 				params := odin.Instance{
 					Identifier: test.identifier,
-					Type:     test.instanceType,
-					User:     test.user,
-					Password: test.password,
-					Size:     test.size,
+					Type:       test.instanceType,
+					User:       test.user,
+					Password:   test.password,
+					Size:       test.size,
 				}
 				actual, err := odin.CreateInstance(
 					params,

--- a/pkg/odin/instance_create_test.go
+++ b/pkg/odin/instance_create_test.go
@@ -104,6 +104,7 @@ func TestCreateInstance(t *testing.T) {
 			test.name,
 			func(t *testing.T) {
 				params := odin.Instance{
+					Identifier: test.identifier,
 					Type:     test.instanceType,
 					User:     test.user,
 					Password: test.password,

--- a/pkg/odin/instance_create_test.go
+++ b/pkg/odin/instance_create_test.go
@@ -111,7 +111,6 @@ func TestCreateInstance(t *testing.T) {
 					Size:     test.size,
 				}
 				actual, err := odin.CreateInstance(
-					test.identifier,
 					params,
 					svc,
 				)

--- a/pkg/odin/instance_create_test.go
+++ b/pkg/odin/instance_create_test.go
@@ -103,11 +103,11 @@ func TestCreateInstance(t *testing.T) {
 		t.Run(
 			test.name,
 			func(t *testing.T) {
-				params := odin.CreateParams{
-					InstanceType: test.instanceType,
-					User:         test.user,
-					Password:     test.password,
-					Size:         test.size,
+				params := odin.Instance{
+					Type:     test.instanceType,
+					User:     test.user,
+					Password: test.password,
+					Size:     test.size,
 				}
 				actual, err := odin.CreateInstance(
 					test.identifier,

--- a/pkg/odin/instance_delete.go
+++ b/pkg/odin/instance_delete.go
@@ -1,31 +1,24 @@
 package odin
 
 import (
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
 
 // DeleteInstance deletes an existing RDS database instance.
 func DeleteInstance(
-	identifier string,
-	snapshotID string,
+	params Instance,
 	svc rdsiface.RDSAPI,
-) error {
-	params := &rds.DeleteDBInstanceInput{
-		DBInstanceIdentifier: aws.String(identifier),
-	}
-	if snapshotID == "" {
-		params.SkipFinalSnapshot = aws.Bool(true)
-	} else {
-		params.FinalDBSnapshotIdentifier = aws.String(snapshotID)
+) (err error) {
+	rdsParams, err := params.DeleteDBInput(svc)
+	if err != nil {
+		return err
 	}
 	out, err := svc.DeleteDBInstance(
-		params,
+		rdsParams,
 	)
 	if err != nil {
 		return err
 	}
-	WaitForInstance(out.DBInstance, svc, "deleted")
+	err = WaitForInstance(out.DBInstance, svc, "deleted")
 	return nil
 }

--- a/pkg/odin/instance_delete_test.go
+++ b/pkg/odin/instance_delete_test.go
@@ -73,7 +73,7 @@ func TestDeleteInstance(t *testing.T) {
 				svc.addInstances(test.instances)
 				err := odin.DeleteInstance(
 					odin.Instance{
-						Identifier: test.identifier,
+						Identifier:      test.identifier,
 						FinalSnapshotID: test.snapshotID,
 					},
 					svc,

--- a/pkg/odin/instance_delete_test.go
+++ b/pkg/odin/instance_delete_test.go
@@ -72,8 +72,10 @@ func TestDeleteInstance(t *testing.T) {
 			func(t *testing.T) {
 				svc.addInstances(test.instances)
 				err := odin.DeleteInstance(
-					test.identifier,
-					test.snapshotID,
+					odin.Instance{
+						Identifier: test.identifier,
+						FinalSnapshotID: test.snapshotID,
+					},
 					svc,
 				)
 				test.check("", err, t)

--- a/pkg/odin/instance_restore.go
+++ b/pkg/odin/instance_restore.go
@@ -44,17 +44,9 @@ func doRestore(
 	if err != nil {
 		return
 	}
-	if err = rdsParams.Validate(); err != nil {
-		err = fmt.Errorf(
-			"DB instance parameters failed to validate: %s",
-			err,
-		)
-		return
-	}
 	res, err = svc.RestoreDBInstanceFromDBSnapshot(rdsParams)
 	if err != nil {
 		return
 	}
-	instance = res.DBInstance
-	return
+	return res.DBInstance, nil
 }

--- a/pkg/odin/instance_restore.go
+++ b/pkg/odin/instance_restore.go
@@ -1,7 +1,6 @@
 package odin
 
 import (
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
 
@@ -11,14 +10,13 @@ func RestoreInstance(
 	params Instance,
 	svc rdsiface.RDSAPI,
 ) (result string, err error) {
-	var res *rds.RestoreDBInstanceFromDBSnapshotOutput
 	rdsParams, err := params.RestoreDBInput(
 		svc,
 	)
 	if err != nil {
 		return "", err
 	}
-	res, err = svc.RestoreDBInstanceFromDBSnapshot(rdsParams)
+	res, err := svc.RestoreDBInstanceFromDBSnapshot(rdsParams)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/odin/instance_restore.go
+++ b/pkg/odin/instance_restore.go
@@ -1,8 +1,6 @@
 package odin
 
 import (
-	"fmt"
-
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
@@ -14,39 +12,22 @@ func RestoreInstance(
 	params Instance,
 	svc rdsiface.RDSAPI,
 ) (result string, err error) {
-	var instance *rds.DBInstance
-	instance, err = doRestore(instanceName, params, svc)
-	if err != nil {
-		return
-	}
-	err = WaitForInstance(instance, svc, "available")
-	if err != nil {
-		return
-	}
-	result = *instance.Endpoint.Address
-	err = modifyInstance(instanceName, params, svc)
-	return
-}
-
-func doRestore(
-	instanceName string,
-	params Instance,
-	svc rdsiface.RDSAPI,
-) (
-	instance *rds.DBInstance,
-	err error,
-) {
 	var res *rds.RestoreDBInstanceFromDBSnapshotOutput
 	rdsParams, err := params.RestoreDBInput(
-		instanceName,
 		svc,
 	)
 	if err != nil {
-		return
+		return "", err
 	}
 	res, err = svc.RestoreDBInstanceFromDBSnapshot(rdsParams)
 	if err != nil {
-		return
+		return "", err
 	}
-	return res.DBInstance, nil
+	err = WaitForInstance(res.DBInstance, svc, "available")
+	if err != nil {
+		return "", err
+	}
+	result = *res.DBInstance.Endpoint.Address
+	err = modifyInstance(instanceName, params, svc)
+	return
 }

--- a/pkg/odin/instance_restore.go
+++ b/pkg/odin/instance_restore.go
@@ -8,7 +8,6 @@ import (
 // RestoreInstance creates a new RDS database instance restoring
 // from a snapshot.
 func RestoreInstance(
-	instanceName string,
 	params Instance,
 	svc rdsiface.RDSAPI,
 ) (result string, err error) {
@@ -28,6 +27,6 @@ func RestoreInstance(
 		return "", err
 	}
 	result = *res.DBInstance.Endpoint.Address
-	err = modifyInstance(instanceName, params, svc)
+	err = modifyInstance(params, svc)
 	return
 }

--- a/pkg/odin/instance_restore.go
+++ b/pkg/odin/instance_restore.go
@@ -3,72 +3,15 @@ package odin
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
-
-// RestoreParams represents instance restoring parameters.
-type RestoreParams struct {
-	InstanceType         string
-	SubnetGroupName      string
-	SecurityGroups       []string
-	OriginalInstanceName string
-}
-
-// GetRestoreDBInput method creates a new
-// RestoreDBInstanceFromDBSnapshotInput from provided CreateDBParams and
-// rds.DBSnapshot.
-func (p RestoreParams) GetRestoreDBInput(
-	identifier string,
-	svc rdsiface.RDSAPI,
-) (
-	out *rds.RestoreDBInstanceFromDBSnapshotInput,
-	err error,
-) {
-	if p.OriginalInstanceName == "" {
-		err = fmt.Errorf("Original Instance Name was empty")
-		return
-	}
-	snapshot, err := GetLastSnapshot(p.OriginalInstanceName, svc)
-	if err != nil {
-		err = fmt.Errorf(
-			"No snapshot found for %s instance",
-			p.OriginalInstanceName,
-		)
-		return
-	}
-	out = &rds.RestoreDBInstanceFromDBSnapshotInput{
-		DBInstanceClass:      &p.InstanceType,
-		DBInstanceIdentifier: &identifier,
-		DBSnapshotIdentifier: snapshot.DBSnapshotIdentifier,
-		DBSubnetGroupName:    &p.SubnetGroupName,
-		Engine:               aws.String("postgres"),
-	}
-	return
-}
-
-// GetModifyDBInput method creates a new ModifyDBInstanceInput
-// from provided ModifyDBParams and rds.DBSnapshot.
-func (p RestoreParams) GetModifyDBInput(
-	identifier string,
-	svc rdsiface.RDSAPI,
-) *rds.ModifyDBInstanceInput {
-	SecurityGroups := []*string{}
-	for _, sgid := range p.SecurityGroups {
-		SecurityGroups = append(SecurityGroups, aws.String(sgid))
-	}
-	return &rds.ModifyDBInstanceInput{
-		DBInstanceIdentifier: &identifier,
-		VpcSecurityGroupIds:  SecurityGroups,
-	}
-}
 
 // RestoreInstance creates a new RDS database instance restoring
 // from a snapshot.
 func RestoreInstance(
 	instanceName string,
-	params RestoreParams,
+	params Instance,
 	svc rdsiface.RDSAPI,
 ) (result string, err error) {
 	var instance *rds.DBInstance
@@ -87,14 +30,14 @@ func RestoreInstance(
 
 func doRestore(
 	instanceName string,
-	params RestoreParams,
+	params Instance,
 	svc rdsiface.RDSAPI,
 ) (
 	instance *rds.DBInstance,
 	err error,
 ) {
 	var res *rds.RestoreDBInstanceFromDBSnapshotOutput
-	rdsParams, err := params.GetRestoreDBInput(
+	rdsParams, err := params.RestoreDBInput(
 		instanceName,
 		svc,
 	)

--- a/pkg/odin/instance_restore_test.go
+++ b/pkg/odin/instance_restore_test.go
@@ -32,8 +32,8 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 			expectedError: "",
 		},
 		name:       "Params with Snapshot",
-		identifier: "develop",
 		params: odin.Instance{
+			Identifier: "develop",
 			Type:                 "db.m1.medium",
 			OriginalInstanceName: "production-rds",
 		},
@@ -46,8 +46,8 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 			expectedError: "Original Instance Name was empty",
 		},
 		name:       "Params with Snapshot without OriginalInstanceName",
-		identifier: "production-rds",
 		params: odin.Instance{
+			Identifier: "production-rds",
 			Type: "db.m1.medium",
 		},
 		snapshots: []*rds.DBSnapshot{exampleSnapshot1},
@@ -59,8 +59,8 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 			expectedError: "No snapshot found for develop instance",
 		},
 		name:       "Params with non existing Snapshot",
-		identifier: "production-rds",
 		params: odin.Instance{
+			Identifier: "production-rds",
 			Type:                 "db.m1.medium",
 			OriginalInstanceName: "develop",
 		},
@@ -77,7 +77,6 @@ func TestGetRestoreDBInput(t *testing.T) {
 				svc.AddSnapshots(test.snapshots)
 				params := test.params
 				actual, err := params.RestoreDBInput(
-					test.identifier,
 					svc,
 				)
 				test.check(actual, err, t)
@@ -130,6 +129,7 @@ func TestRestoreInstance(t *testing.T) {
 					svc.AddSnapshots(test.snapshots)
 				}
 				params := odin.Instance{
+					Identifier: test.identifier,
 					Type:                 test.instanceType,
 					OriginalInstanceName: test.from,
 				}

--- a/pkg/odin/instance_restore_test.go
+++ b/pkg/odin/instance_restore_test.go
@@ -14,7 +14,7 @@ type getRestoreDBInputCase struct {
 	testCase
 	name       string
 	identifier string
-	params     odin.RestoreParams
+	params     odin.Instance
 	snapshots  []*rds.DBSnapshot
 }
 
@@ -33,8 +33,8 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 		},
 		name:       "Params with Snapshot",
 		identifier: "develop",
-		params: odin.RestoreParams{
-			InstanceType:         "db.m1.medium",
+		params: odin.Instance{
+			Type:                 "db.m1.medium",
 			OriginalInstanceName: "production-rds",
 		},
 		snapshots: []*rds.DBSnapshot{exampleSnapshot1},
@@ -47,8 +47,8 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 		},
 		name:       "Params with Snapshot without OriginalInstanceName",
 		identifier: "production-rds",
-		params: odin.RestoreParams{
-			InstanceType: "db.m1.medium",
+		params: odin.Instance{
+			Type: "db.m1.medium",
 		},
 		snapshots: []*rds.DBSnapshot{exampleSnapshot1},
 	},
@@ -60,8 +60,8 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 		},
 		name:       "Params with non existing Snapshot",
 		identifier: "production-rds",
-		params: odin.RestoreParams{
-			InstanceType:         "db.m1.medium",
+		params: odin.Instance{
+			Type:                 "db.m1.medium",
 			OriginalInstanceName: "develop",
 		},
 		snapshots: []*rds.DBSnapshot{exampleSnapshot1},
@@ -76,7 +76,7 @@ func TestGetRestoreDBInput(t *testing.T) {
 			func(t *testing.T) {
 				svc.AddSnapshots(test.snapshots)
 				params := test.params
-				actual, err := params.GetRestoreDBInput(
+				actual, err := params.RestoreDBInput(
 					test.identifier,
 					svc,
 				)
@@ -129,8 +129,8 @@ func TestRestoreInstance(t *testing.T) {
 				if test.from != "" {
 					svc.AddSnapshots(test.snapshots)
 				}
-				params := odin.RestoreParams{
-					InstanceType:         test.instanceType,
+				params := odin.Instance{
+					Type:                 test.instanceType,
 					OriginalInstanceName: test.from,
 				}
 				actual, err := odin.RestoreInstance(

--- a/pkg/odin/instance_restore_test.go
+++ b/pkg/odin/instance_restore_test.go
@@ -31,9 +31,9 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 			},
 			expectedError: "",
 		},
-		name:       "Params with Snapshot",
+		name: "Params with Snapshot",
 		params: odin.Instance{
-			Identifier: "develop",
+			Identifier:           "develop",
 			Type:                 "db.m1.medium",
 			OriginalInstanceName: "production-rds",
 		},
@@ -45,10 +45,10 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 			expected:      nil,
 			expectedError: "Original Instance Name was empty",
 		},
-		name:       "Params with Snapshot without OriginalInstanceName",
+		name: "Params with Snapshot without OriginalInstanceName",
 		params: odin.Instance{
 			Identifier: "production-rds",
-			Type: "db.m1.medium",
+			Type:       "db.m1.medium",
 		},
 		snapshots: []*rds.DBSnapshot{exampleSnapshot1},
 	},
@@ -58,9 +58,9 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 			expected:      nil,
 			expectedError: "No snapshot found for develop instance",
 		},
-		name:       "Params with non existing Snapshot",
+		name: "Params with non existing Snapshot",
 		params: odin.Instance{
-			Identifier: "production-rds",
+			Identifier:           "production-rds",
 			Type:                 "db.m1.medium",
 			OriginalInstanceName: "develop",
 		},
@@ -129,7 +129,7 @@ func TestRestoreInstance(t *testing.T) {
 					svc.AddSnapshots(test.snapshots)
 				}
 				params := odin.Instance{
-					Identifier: test.identifier,
+					Identifier:           test.identifier,
 					Type:                 test.instanceType,
 					OriginalInstanceName: test.from,
 				}

--- a/pkg/odin/instance_restore_test.go
+++ b/pkg/odin/instance_restore_test.go
@@ -134,7 +134,6 @@ func TestRestoreInstance(t *testing.T) {
 					OriginalInstanceName: test.from,
 				}
 				actual, err := odin.RestoreInstance(
-					test.identifier,
 					params,
 					svc,
 				)

--- a/pkg/odin/instance_scale.go
+++ b/pkg/odin/instance_scale.go
@@ -24,10 +24,9 @@ func ScaleInstance(
 	if err != nil {
 		return "", err
 	}
-	result = fmt.Sprintf(
+	return fmt.Sprintf(
 		"Instance %s is %s",
 		*out.DBInstance.DBInstanceIdentifier,
 		*out.DBInstance.DBInstanceClass,
-	)
-	return
+	), nil
 }

--- a/pkg/odin/instance_scale.go
+++ b/pkg/odin/instance_scale.go
@@ -3,32 +3,26 @@ package odin
 import (
 	"fmt"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 )
 
 // ScaleInstance scales an existing RDS database instance.
 func ScaleInstance(
-	instanceName string,
-	instanceType string,
+	params Instance,
 	delayChange bool,
 	svc rdsiface.RDSAPI,
 ) (result string, err error) {
-	in := &rds.ModifyDBInstanceInput{
-		DBInstanceIdentifier: aws.String(instanceName),
-		DBInstanceClass:      aws.String(instanceType),
-	}
-	if !delayChange {
-		in.ApplyImmediately = aws.Bool(true)
-	}
-	out, err := svc.ModifyDBInstance(in)
+	rdsParams, err := params.ModifyDBInput(!delayChange, svc)
 	if err != nil {
-		return
+		return "", err
+	}
+	out, err := svc.ModifyDBInstance(rdsParams)
+	if err != nil {
+		return "", err
 	}
 	err = WaitForInstance(out.DBInstance, svc, "available")
 	if err != nil {
-		return
+		return "", err
 	}
 	result = fmt.Sprintf(
 		"Instance %s is %s",

--- a/pkg/odin/instance_scale_test.go
+++ b/pkg/odin/instance_scale_test.go
@@ -115,8 +115,10 @@ func TestScaleInstance(t *testing.T) {
 			func(t *testing.T) {
 				svc.addInstances(test.instances)
 				actual, err := odin.ScaleInstance(
-					test.identifier,
-					test.instanceType,
+					odin.Instance{
+						Identifier: test.identifier,
+						Type: test.instanceType,
+					},
 					test.delayChange,
 					svc,
 				)

--- a/pkg/odin/instance_scale_test.go
+++ b/pkg/odin/instance_scale_test.go
@@ -117,7 +117,7 @@ func TestScaleInstance(t *testing.T) {
 				actual, err := odin.ScaleInstance(
 					odin.Instance{
 						Identifier: test.identifier,
-						Type: test.instanceType,
+						Type:       test.instanceType,
 					},
 					test.delayChange,
 					svc,

--- a/pkg/odin/odin.go
+++ b/pkg/odin/odin.go
@@ -23,7 +23,7 @@ func Init() rdsiface.RDSAPI {
 // ModifiableParams is interface for params structs supporting
 // DBInstance modification.
 type ModifiableParams interface {
-	ModifyDBInput(string, rdsiface.RDSAPI) *rds.ModifyDBInstanceInput
+	ModifyDBInput(rdsiface.RDSAPI) (*rds.ModifyDBInstanceInput, error)
 }
 
 func modifyInstance(
@@ -31,19 +31,14 @@ func modifyInstance(
 	params ModifiableParams,
 	svc rdsiface.RDSAPI,
 ) (err error) {
-	rdsParams := params.ModifyDBInput(
-		instanceName,
+	rdsParams, err := params.ModifyDBInput(
 		svc,
 	)
-	if err = rdsParams.Validate(); err != nil {
-		err = fmt.Errorf(
-			"DB instance parameters failed to validate: %s",
-			err,
-		)
-		return
+	if err != nil {
+		return err
 	}
 	_, err = svc.ModifyDBInstance(rdsParams)
-	return
+	return err
 }
 
 // GetLastSnapshot queries AWS looking for a Snapshot ID, depending on

--- a/pkg/odin/odin.go
+++ b/pkg/odin/odin.go
@@ -23,7 +23,7 @@ func Init() rdsiface.RDSAPI {
 // ModifiableParams is interface for params structs supporting
 // DBInstance modification.
 type ModifiableParams interface {
-	ModifyDBInput(rdsiface.RDSAPI) (*rds.ModifyDBInstanceInput, error)
+	ModifyDBInput(bool, rdsiface.RDSAPI) (*rds.ModifyDBInstanceInput, error)
 }
 
 func modifyInstance(
@@ -32,6 +32,7 @@ func modifyInstance(
 	svc rdsiface.RDSAPI,
 ) (err error) {
 	rdsParams, err := params.ModifyDBInput(
+		false,
 		svc,
 	)
 	if err != nil {

--- a/pkg/odin/odin.go
+++ b/pkg/odin/odin.go
@@ -23,7 +23,7 @@ func Init() rdsiface.RDSAPI {
 // ModifiableParams is interface for params structs supporting
 // DBInstance modification.
 type ModifiableParams interface {
-	GetModifyDBInput(string, rdsiface.RDSAPI) *rds.ModifyDBInstanceInput
+	ModifyDBInput(string, rdsiface.RDSAPI) *rds.ModifyDBInstanceInput
 }
 
 func modifyInstance(
@@ -31,7 +31,7 @@ func modifyInstance(
 	params ModifiableParams,
 	svc rdsiface.RDSAPI,
 ) (err error) {
-	rdsParams := params.GetModifyDBInput(
+	rdsParams := params.ModifyDBInput(
 		instanceName,
 		svc,
 	)

--- a/pkg/odin/odin.go
+++ b/pkg/odin/odin.go
@@ -27,7 +27,6 @@ type ModifiableParams interface {
 }
 
 func modifyInstance(
-	instanceName string,
 	params ModifiableParams,
 	svc rdsiface.RDSAPI,
 ) (err error) {


### PR DESCRIPTION
**Unify Instance representations in single struct**
Introduce new struct `odin.Instance` consolidating behaviour for
`create`, `clone`, `modify` and `restore` operations on
instances.

Rewire all existing tests and commands to depend on the new
structure.

**Refactor Instance methods**
Rename the internal reference to the struct for the members, unify
handling of return values, reuse AddLastSnapshot method.

**Add CloneDBInput method to Instance**
This provides a primitive for the `clone` operation hiding the small
differences between `clone` and `create`.

**Unexport and simplify AddLastSnapshot**
As we are now the only consumers of this method, unexport it and
simplify it for our preset use cases. This also consolidates the
operation primitives as Public API for Instance operations.

**Move validation of restore inputs to Instance**
When we generate AWS structures for use they must be already
validated. Migrate this validation step to Instance's method
RestoreDBInput.

**Move validation of modify inputs to Instance**
Make sure the structures we generate for ModifyDBInput are valid.

**Include Identifier as property of Instance**
Add a new Identifier property to the Instance struct to represent the
Instance's Identifier and remove the Identifier from the public API of
all Instance methods.

Also fuse the do<verb> methods that no longer make sense.

**Add Delete verb to Instance**
Add method to Delete DB instances and make all clients use it.

**Make scale operation use Instance**
The scale operations now use the Modify verb of Instance.

**Remove useless instanceName parameter**
We only use the Identifier parameter in Instance now.

**Fix misc spacing issues detected by gofmt**

**Move input verification to command**
Verify input is complete in the command instead of the package.

**Minor misc syntax/arrangement improvements**