### PR TITLE
Extract test case objects from odin

### DIFF
--- a/internal/test_case/test_case.go
+++ b/internal/test_case/test_case.go
@@ -1,0 +1,47 @@
+package testcase
+
+import (
+	"testing"
+
+	"github.com/go-test/deep"
+)
+
+// TestCase contains the basic elements of a test case:
+//   * expected is what should be got.
+//   * expectedError is the string of the error message in case of such error being expected.
+type TestCase struct {
+	Expected      interface{}
+	ExpectedError string
+}
+
+// expectingError helps determine if the case was expecting an specific error.
+func (tc *TestCase) expectingError(err error) bool {
+	return tc.ExpectedError != "" && err.Error() == tc.ExpectedError
+}
+
+// Check is to be used by the test executor to validate the case is passing.
+func (tc *TestCase) Check(actual interface{}, err error, t *testing.T) {
+	switch {
+	case err != nil && !tc.expectingError(err):
+		t.Errorf(
+			"Unexpected error: %v",
+			err,
+		)
+	case err != nil && tc.expectingError(err):
+	case err == nil && tc.ExpectedError != "":
+		t.Errorf(
+			"Expected error: %v missing",
+			tc.ExpectedError,
+		)
+	case err == nil:
+		if diff := deep.Equal(
+			actual,
+			tc.Expected,
+		); diff != nil {
+			t.Errorf(
+				"Unexpected output: %s",
+				diff,
+			)
+		}
+	}
+}

--- a/pkg/odin/instance_clone_test.go
+++ b/pkg/odin/instance_clone_test.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/rds"
 
+	"github.com/poka-yoke/spaceflight/internal/test_case"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
 type cloneInstanceCase struct {
-	testCase
+	testcase.TestCase
 	name         string
 	identifier   string
 	instanceType string
@@ -24,9 +25,9 @@ type cloneInstanceCase struct {
 var cloneInstanceCases = []cloneInstanceCase{
 	// Uses snapshot to copy from
 	{
-		testCase: testCase{
-			expected:      "test1.0.us-east-1.rds.amazonaws.com",
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      "test1.0.us-east-1.rds.amazonaws.com",
+			ExpectedError: "",
 		},
 		name:         "Uses snapshot to copy from",
 		identifier:   "test1",
@@ -39,9 +40,9 @@ var cloneInstanceCases = []cloneInstanceCase{
 	},
 	// Uses non existing snapshot to copy from
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "No snapshot found for develop instance",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "No snapshot found for develop instance",
 		},
 		name:         "Uses non existing snapshot to copy from",
 		identifier:   "test1",
@@ -76,7 +77,7 @@ func TestCloneInstance(t *testing.T) {
 					params,
 					svc,
 				)
-				test.check(actual, err, t)
+				test.Check(actual, err, t)
 			},
 		)
 	}

--- a/pkg/odin/instance_create_test.go
+++ b/pkg/odin/instance_create_test.go
@@ -4,11 +4,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/poka-yoke/spaceflight/internal/test_case"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
 type createInstanceCase struct {
-	testCase
+	testcase.TestCase
 	name         string
 	identifier   string
 	instanceType string
@@ -20,9 +21,9 @@ type createInstanceCase struct {
 var createInstanceCases = []createInstanceCase{
 	// Creating simple instance
 	{
-		testCase: testCase{
-			expected:      "test1.0.us-east-1.rds.amazonaws.com",
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      "test1.0.us-east-1.rds.amazonaws.com",
+			ExpectedError: "",
 		},
 		name:         "Creating simple instance",
 		identifier:   "test1",
@@ -33,9 +34,9 @@ var createInstanceCases = []createInstanceCase{
 	},
 	// Fail because empty user
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "Specify Master User",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "Specify Master User",
 		},
 		name:         "Fail because empty user",
 		identifier:   "test1",
@@ -46,9 +47,9 @@ var createInstanceCases = []createInstanceCase{
 	},
 	// Fail because empty password
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "Specify Master User Password",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "Specify Master User Password",
 		},
 		name:         "Fail because empty password",
 		identifier:   "test1",
@@ -59,9 +60,9 @@ var createInstanceCases = []createInstanceCase{
 	},
 	// Fail because non-present size
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "Specify size between 5 and 6144",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "Specify size between 5 and 6144",
 		},
 		name:         "Fail because non-present size",
 		identifier:   "test1",
@@ -71,9 +72,9 @@ var createInstanceCases = []createInstanceCase{
 	},
 	// Fail because too small size
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "Specify size between 5 and 6144",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "Specify size between 5 and 6144",
 		},
 		name:         "Fail because too small size",
 		identifier:   "test1",
@@ -83,9 +84,9 @@ var createInstanceCases = []createInstanceCase{
 	},
 	// Fail because too big size
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "Specify size between 5 and 6144",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "Specify size between 5 and 6144",
 		},
 		name:         "Fail because too big size",
 		identifier:   "test1",
@@ -114,7 +115,7 @@ func TestCreateInstance(t *testing.T) {
 					params,
 					svc,
 				)
-				test.check(actual, err, t)
+				test.Check(actual, err, t)
 			},
 		)
 	}

--- a/pkg/odin/instance_delete_test.go
+++ b/pkg/odin/instance_delete_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
+	"github.com/poka-yoke/spaceflight/internal/test_case"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
 type deleteInstanceCase struct {
-	testCase
+	testcase.TestCase
 	name       string
 	identifier string
 	snapshotID string
@@ -21,9 +22,9 @@ type deleteInstanceCase struct {
 var deleteInstanceCases = []deleteInstanceCase{
 	// Deleting simple instance
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "",
 		},
 		name:       "Deleting simple instance",
 		identifier: "test1",
@@ -37,9 +38,9 @@ var deleteInstanceCases = []deleteInstanceCase{
 	},
 	// Deleting simple instance with final snapshot
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "",
 		},
 		name:       "Deleting simple instance with final snapshot",
 		identifier: "test3",
@@ -53,9 +54,9 @@ var deleteInstanceCases = []deleteInstanceCase{
 	},
 	// Deleting non existing instance
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "No such instance test2",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "No such instance test2",
 		},
 		name:       "Deleting non existing instance",
 		identifier: "test2",
@@ -78,7 +79,7 @@ func TestDeleteInstance(t *testing.T) {
 					},
 					svc,
 				)
-				test.check("", err, t)
+				test.Check("", err, t)
 				_, instance, _ := svc.findInstance(
 					test.identifier,
 				)

--- a/pkg/odin/instance_restore_test.go
+++ b/pkg/odin/instance_restore_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
+	"github.com/poka-yoke/spaceflight/internal/test_case"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
 type getRestoreDBInputCase struct {
-	testCase
+	testcase.TestCase
 	name       string
 	identifier string
 	params     odin.Instance
@@ -21,15 +22,15 @@ type getRestoreDBInputCase struct {
 var getRestoreDBInputCases = []getRestoreDBInputCase{
 	// Params with Snapshot
 	{
-		testCase: testCase{
-			expected: &rds.RestoreDBInstanceFromDBSnapshotInput{
+		TestCase: testcase.TestCase{
+			Expected: &rds.RestoreDBInstanceFromDBSnapshotInput{
 				DBInstanceClass:      exampleSnapshot1Type,
 				DBInstanceIdentifier: aws.String("develop"),
 				DBSnapshotIdentifier: exampleSnapshot1ID,
 				DBSubnetGroupName:    aws.String(""),
 				Engine:               aws.String("postgres"),
 			},
-			expectedError: "",
+			ExpectedError: "",
 		},
 		name: "Params with Snapshot",
 		params: odin.Instance{
@@ -41,9 +42,9 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 	},
 	// Params with Snapshot without OriginalInstanceName
 	{
-		testCase: testCase{
-			expected:      nil,
-			expectedError: "Original Instance Name was empty",
+		TestCase: testcase.TestCase{
+			Expected:      nil,
+			ExpectedError: "Original Instance Name was empty",
 		},
 		name: "Params with Snapshot without OriginalInstanceName",
 		params: odin.Instance{
@@ -54,9 +55,9 @@ var getRestoreDBInputCases = []getRestoreDBInputCase{
 	},
 	// Params with non existing Snapshot
 	{
-		testCase: testCase{
-			expected:      nil,
-			expectedError: "No snapshot found for develop instance",
+		TestCase: testcase.TestCase{
+			Expected:      nil,
+			ExpectedError: "No snapshot found for develop instance",
 		},
 		name: "Params with non existing Snapshot",
 		params: odin.Instance{
@@ -79,7 +80,7 @@ func TestGetRestoreDBInput(t *testing.T) {
 				actual, err := params.RestoreDBInput(
 					svc,
 				)
-				test.check(actual, err, t)
+				test.Check(actual, err, t)
 			},
 		)
 	}
@@ -88,9 +89,9 @@ func TestGetRestoreDBInput(t *testing.T) {
 var restoreInstanceCases = []cloneInstanceCase{
 	// Uses snapshot to restore from
 	{
-		testCase: testCase{
-			expected:      "test1.0.us-east-1.rds.amazonaws.com",
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      "test1.0.us-east-1.rds.amazonaws.com",
+			ExpectedError: "",
 		},
 		name:         "Uses snapshot to restore from",
 		identifier:   "test1",
@@ -103,9 +104,9 @@ var restoreInstanceCases = []cloneInstanceCase{
 	},
 	// Uses non existing snapshot to restore from
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "No snapshot found for develop instance",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "No snapshot found for develop instance",
 		},
 		name:         "Uses non existing snapshot to restore from",
 		identifier:   "test1",
@@ -137,7 +138,7 @@ func TestRestoreInstance(t *testing.T) {
 					params,
 					svc,
 				)
-				test.check(actual, err, t)
+				test.Check(actual, err, t)
 			},
 		)
 	}

--- a/pkg/odin/instance_scale_test.go
+++ b/pkg/odin/instance_scale_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
+	"github.com/poka-yoke/spaceflight/internal/test_case"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
 type scaleInstanceCase struct {
-	testCase
+	testcase.TestCase
 	name         string
 	identifier   string
 	instanceType string
@@ -22,9 +23,9 @@ type scaleInstanceCase struct {
 var scaleInstanceCases = []scaleInstanceCase{
 	// Scaling up instance
 	{
-		testCase: testCase{
-			expected:      "Instance test1 is db.m1.small",
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      "Instance test1 is db.m1.small",
+			ExpectedError: "",
 		},
 		name:         "Scaling up instance",
 		identifier:   "test1",
@@ -40,9 +41,9 @@ var scaleInstanceCases = []scaleInstanceCase{
 	},
 	// Fail to scale up non existing instance
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "No such instance test1",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "No such instance test1",
 		},
 		name:         "Fail to scale up non existing instance",
 		identifier:   "test1",
@@ -52,9 +53,9 @@ var scaleInstanceCases = []scaleInstanceCase{
 	},
 	// Fail to scale up non available instance
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "test1 instance state is not available",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "test1 instance state is not available",
 		},
 		name:         "Fail to scale up non available instance",
 		identifier:   "test1",
@@ -70,9 +71,9 @@ var scaleInstanceCases = []scaleInstanceCase{
 	},
 	// Scaling down instance
 	{
-		testCase: testCase{
-			expected:      "Instance test1 is db.m1.small",
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      "Instance test1 is db.m1.small",
+			ExpectedError: "",
 		},
 		name:         "Scaling down instance",
 		identifier:   "test1",
@@ -88,9 +89,9 @@ var scaleInstanceCases = []scaleInstanceCase{
 	},
 	// Delayed scaling down instance
 	{
-		testCase: testCase{
-			expected:      "Instance test1 is db.m1.medium",
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      "Instance test1 is db.m1.medium",
+			ExpectedError: "",
 		},
 		name:         "Scaling down instance with delay",
 		identifier:   "test1",
@@ -122,7 +123,7 @@ func TestScaleInstance(t *testing.T) {
 					test.delayChange,
 					svc,
 				)
-				test.check(actual, err, t)
+				test.Check(actual, err, t)
 			},
 		)
 	}

--- a/pkg/odin/odin_test.go
+++ b/pkg/odin/odin_test.go
@@ -4,48 +4,13 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/rds"
-	"github.com/go-test/deep"
 
+	"github.com/poka-yoke/spaceflight/internal/test_case"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
-type testCase struct {
-	expected      interface{}
-	expectedError string
-}
-
-func (tc *testCase) expectingError(err error) bool {
-	return tc.expectedError != "" && err.Error() == tc.expectedError
-}
-
-func (tc *testCase) check(actual interface{}, err error, t *testing.T) {
-	switch {
-	case err != nil && !tc.expectingError(err):
-		t.Errorf(
-			"Unexpected error: %v",
-			err,
-		)
-	case err != nil && tc.expectingError(err):
-	case err == nil && tc.expectedError != "":
-		t.Errorf(
-			"Expected error: %v missing",
-			tc.expectedError,
-		)
-	case err == nil:
-		if diff := deep.Equal(
-			actual,
-			tc.expected,
-		); diff != nil {
-			t.Errorf(
-				"Unexpected output: %s",
-				diff,
-			)
-		}
-	}
-}
-
 type getLastSnapshotCase struct {
-	testCase
+	testcase.TestCase
 	name       string
 	identifier string
 	snapshots  []*rds.DBSnapshot
@@ -54,9 +19,9 @@ type getLastSnapshotCase struct {
 var getLastSnapshotCases = []getLastSnapshotCase{
 	// Get snapshot id by instance id
 	{
-		testCase: testCase{
-			expected:      exampleSnapshot1,
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      exampleSnapshot1,
+			ExpectedError: "",
 		},
 		name:       "Get snapshot id by instance id",
 		identifier: "production-rds",
@@ -66,9 +31,9 @@ var getLastSnapshotCases = []getLastSnapshotCase{
 	},
 	// Get non-existing snapshot id by instance id
 	{
-		testCase: testCase{
-			expected:      nil,
-			expectedError: "No snapshot found for develop instance",
+		TestCase: testcase.TestCase{
+			Expected:      nil,
+			ExpectedError: "No snapshot found for develop instance",
 		},
 		name:       "Get non-existing snapshot id by instance id",
 		identifier: "develop",
@@ -76,9 +41,9 @@ var getLastSnapshotCases = []getLastSnapshotCase{
 	},
 	// Get last snapshot id by instance id out of two
 	{
-		testCase: testCase{
-			expected:      exampleSnapshot3,
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      exampleSnapshot3,
+			ExpectedError: "",
 		},
 		name:       "Get last snapshot id by instance id",
 		identifier: "develop-rds",
@@ -100,7 +65,7 @@ func TestGetLastSnapshot(t *testing.T) {
 					test.identifier,
 					svc,
 				)
-				test.check(actual, err, t)
+				test.Check(actual, err, t)
 			},
 		)
 	}

--- a/pkg/odin/snapshot_create_test.go
+++ b/pkg/odin/snapshot_create_test.go
@@ -7,11 +7,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
+	"github.com/poka-yoke/spaceflight/internal/test_case"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
 type createSnapshotsCase struct {
-	testCase
+	testcase.TestCase
 	name       string
 	instances  []*rds.DBInstance
 	snapshots  []*rds.DBSnapshot
@@ -32,9 +33,9 @@ var instance2 = &rds.DBInstance{
 var createSnapshotCases = []createSnapshotsCase{
 	// Create simple snapshot
 	{
-		testCase: testCase{
-			expected:      exampleSnapshot4,
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      exampleSnapshot4,
+			ExpectedError: "",
 		},
 		name:       "Create simple snapshot",
 		instances:  []*rds.DBInstance{instance1},
@@ -44,9 +45,9 @@ var createSnapshotCases = []createSnapshotsCase{
 	},
 	// Snapshot already exists
 	{
-		testCase: testCase{
-			expected: nil,
-			expectedError: fmt.Sprintf(
+		TestCase: testcase.TestCase{
+			Expected: nil,
+			ExpectedError: fmt.Sprintf(
 				"Snapshot %s already exists",
 				*exampleSnapshot4ID,
 			),
@@ -59,9 +60,9 @@ var createSnapshotCases = []createSnapshotsCase{
 	},
 	// Invalid instance state
 	{
-		testCase: testCase{
-			expected: nil,
-			expectedError: fmt.Sprintf(
+		TestCase: testcase.TestCase{
+			Expected: nil,
+			ExpectedError: fmt.Sprintf(
 				"%s instance state is not available",
 				*exampleSnapshot4DBID,
 			),
@@ -74,9 +75,9 @@ var createSnapshotCases = []createSnapshotsCase{
 	},
 	// Non existing instance
 	{
-		testCase: testCase{
-			expected: nil,
-			expectedError: fmt.Sprintf(
+		TestCase: testcase.TestCase{
+			Expected: nil,
+			ExpectedError: fmt.Sprintf(
 				"No such instance %s",
 				*exampleSnapshot4DBID,
 			),
@@ -102,7 +103,7 @@ func TestCreateSnapshot(t *testing.T) {
 					test.snapshotID,
 					svc,
 				)
-				test.check(actual, err, t)
+				test.Check(actual, err, t)
 			},
 		)
 	}

--- a/pkg/odin/snapshot_list_test.go
+++ b/pkg/odin/snapshot_list_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
+	"github.com/poka-yoke/spaceflight/internal/test_case"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
@@ -83,33 +84,33 @@ var exampleSnapshot2Out = fmt.Sprintf(
 var printSnapshotsCases = []listSnapshotsCase{
 	// No snapshots
 	{
-		testCase: testCase{
-			expected:      "",
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      "",
+			ExpectedError: "",
 		},
 		name:      "No snapshots",
 		snapshots: []*rds.DBSnapshot{},
 	},
 	// One snapshot
 	{
-		testCase: testCase{
-			expected:      exampleSnapshot1Out,
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      exampleSnapshot1Out,
+			ExpectedError: "",
 		},
 		name:      "One snapshot",
 		snapshots: []*rds.DBSnapshot{exampleSnapshot1},
 	},
 	// Two snapshots
 	{
-		testCase: testCase{
-			expected: strings.Join(
+		TestCase: testcase.TestCase{
+			Expected: strings.Join(
 				[]string{
 					exampleSnapshot2Out,
 					exampleSnapshot1Out,
 				},
 				"",
 			),
-			expectedError: "",
+			ExpectedError: "",
 		},
 		name: "Two snapshots",
 		snapshots: []*rds.DBSnapshot{
@@ -127,14 +128,14 @@ func TestPrintSnapshot(t *testing.T) {
 				actual := odin.PrintSnapshots(
 					test.snapshots,
 				)
-				test.check(actual, nil, t)
+				test.Check(actual, nil, t)
 			},
 		)
 	}
 }
 
 type listSnapshotsCase struct {
-	testCase
+	testcase.TestCase
 	name       string
 	snapshots  []*rds.DBSnapshot
 	instanceID string
@@ -143,9 +144,9 @@ type listSnapshotsCase struct {
 var listSnapshotsCases = []listSnapshotsCase{
 	// No snapshots for any instance
 	{
-		testCase: testCase{
-			expected:      []*rds.DBSnapshot{},
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      []*rds.DBSnapshot{},
+			ExpectedError: "",
 		},
 		name:       "No snapshots for any instance",
 		snapshots:  []*rds.DBSnapshot{},
@@ -153,9 +154,9 @@ var listSnapshotsCases = []listSnapshotsCase{
 	},
 	// One instance, one snapshot
 	{
-		testCase: testCase{
-			expected:      []*rds.DBSnapshot{exampleSnapshot1},
-			expectedError: "",
+		TestCase: testcase.TestCase{
+			Expected:      []*rds.DBSnapshot{exampleSnapshot1},
+			ExpectedError: "",
 		},
 		name:       "One instance one snapshot",
 		snapshots:  []*rds.DBSnapshot{exampleSnapshot1},
@@ -163,12 +164,12 @@ var listSnapshotsCases = []listSnapshotsCase{
 	},
 	// Two instances, two snapshots
 	{
-		testCase: testCase{
-			expected: []*rds.DBSnapshot{
+		TestCase: testcase.TestCase{
+			Expected: []*rds.DBSnapshot{
 				exampleSnapshot2,
 				exampleSnapshot1,
 			},
-			expectedError: "",
+			ExpectedError: "",
 		},
 		name: "Two instances two snapshots",
 		snapshots: []*rds.DBSnapshot{
@@ -179,11 +180,11 @@ var listSnapshotsCases = []listSnapshotsCase{
 	},
 	// Instance selection
 	{
-		testCase: testCase{
-			expected: []*rds.DBSnapshot{
+		TestCase: testcase.TestCase{
+			Expected: []*rds.DBSnapshot{
 				exampleSnapshot2,
 			},
-			expectedError: "",
+			ExpectedError: "",
 		},
 		name: "Two instances two snapshots, one selected",
 		snapshots: []*rds.DBSnapshot{
@@ -205,7 +206,7 @@ func TestListSnapshots(t *testing.T) {
 					test.instanceID,
 					svc,
 				)
-				test.check(actual, err, t)
+				test.Check(actual, err, t)
 			},
 		)
 	}


### PR DESCRIPTION
This moves test case definition to a spaceflight internal package so it can be reused in other packages.