### PR TITLE
Rename new internal test objects

### DIFF
--- a/internal/test/case.go
+++ b/internal/test/case.go
@@ -1,4 +1,4 @@
-package testcase
+package test
 
 import (
 	"testing"
@@ -6,37 +6,37 @@ import (
 	"github.com/go-test/deep"
 )
 
-// TestCase contains the basic elements of a test case:
+// Case contains the basic elements of a test case:
 //   * expected is what should be got.
 //   * expectedError is the string of the error message in case of such error being expected.
-type TestCase struct {
+type Case struct {
 	Expected      interface{}
 	ExpectedError string
 }
 
 // expectingError helps determine if the case was expecting an specific error.
-func (tc *TestCase) expectingError(err error) bool {
-	return tc.ExpectedError != "" && err.Error() == tc.ExpectedError
+func (c *Case) expectingError(err error) bool {
+	return c.ExpectedError != "" && err.Error() == c.ExpectedError
 }
 
 // Check is to be used by the test executor to validate the case is passing.
-func (tc *TestCase) Check(actual interface{}, err error, t *testing.T) {
+func (c *Case) Check(actual interface{}, err error, t *testing.T) {
 	switch {
-	case err != nil && !tc.expectingError(err):
+	case err != nil && !c.expectingError(err):
 		t.Errorf(
 			"Unexpected error: %v",
 			err,
 		)
-	case err != nil && tc.expectingError(err):
-	case err == nil && tc.ExpectedError != "":
+	case err != nil && c.expectingError(err):
+	case err == nil && c.ExpectedError != "":
 		t.Errorf(
 			"Expected error: %v missing",
-			tc.ExpectedError,
+			c.ExpectedError,
 		)
 	case err == nil:
 		if diff := deep.Equal(
 			actual,
-			tc.Expected,
+			c.Expected,
 		); diff != nil {
 			t.Errorf(
 				"Unexpected output: %s",

--- a/internal/test/mocks/rds_client.go
+++ b/internal/test/mocks/rds_client.go
@@ -1,4 +1,4 @@
-package mockrdsclient
+package mocks
 
 import (
 	"errors"
@@ -18,8 +18,8 @@ func trimLast(in string) string {
 	return in[:len(in)-1]
 }
 
-// MockRDSClient mocks RDSAPI methods for testing of RDS API clients.
-type MockRDSClient struct {
+// RDSClient mocks RDSAPI methods for testing of RDS API clients.
+type RDSClient struct {
 	rdsiface.RDSAPI
 	dbInstances []*rds.DBInstance
 	dbSnapshots []*rds.DBSnapshot
@@ -27,7 +27,7 @@ type MockRDSClient struct {
 
 // TakeFinalSnapshot emulates taking the final snapshot, if specified,
 // validating params.
-func (m *MockRDSClient) TakeFinalSnapshot(
+func (m *RDSClient) TakeFinalSnapshot(
 	params *rds.DeleteDBInstanceInput,
 ) (err error) {
 	if params.SkipFinalSnapshot == nil {
@@ -56,7 +56,7 @@ func (m *MockRDSClient) TakeFinalSnapshot(
 }
 
 // DeleteDBInstance mocks rds.DeleteDBInstance.
-func (m *MockRDSClient) DeleteDBInstance(
+func (m *RDSClient) DeleteDBInstance(
 	params *rds.DeleteDBInstanceInput,
 ) (
 	result *rds.DeleteDBInstanceOutput,
@@ -79,9 +79,9 @@ func (m *MockRDSClient) DeleteDBInstance(
 	return
 }
 
-// FindSnapshotInstance return index and snapshot in MockRDSClient.dbSnapshots
+// FindSnapshotInstance return index and snapshot in RDSClient.dbSnapshots
 // for a specific instance id.
-func (m MockRDSClient) FindSnapshotInstance(instanceID string) (
+func (m RDSClient) FindSnapshotInstance(instanceID string) (
 	index int,
 	snapshot *rds.DBSnapshot,
 	err error,
@@ -104,9 +104,9 @@ func (m MockRDSClient) FindSnapshotInstance(instanceID string) (
 	return
 }
 
-// FindSnapshot return index and snapshot in MockRDSClient.dbSnapshots
+// FindSnapshot return index and snapshot in RDSClient.dbSnapshots
 // for a specific id.
-func (m MockRDSClient) FindSnapshot(id string) (
+func (m RDSClient) FindSnapshot(id string) (
 	index int,
 	snapshot *rds.DBSnapshot,
 	err error,
@@ -129,9 +129,9 @@ func (m MockRDSClient) FindSnapshot(id string) (
 	return
 }
 
-// findInstance return index and instance in MockRDSClient.dbInstances
+// findInstance return index and instance in RDSClient.dbInstances
 // for a specific id.
-func (m MockRDSClient) findInstance(id string) (
+func (m RDSClient) findInstance(id string) (
 	index int,
 	instance *rds.DBInstance,
 	err error,
@@ -155,7 +155,7 @@ func (m MockRDSClient) findInstance(id string) (
 }
 
 // addInstances add a list of instances to the mock
-func (m *MockRDSClient) addInstances(
+func (m *RDSClient) addInstances(
 	instances []*rds.DBInstance,
 ) {
 	m.dbInstances = []*rds.DBInstance{}
@@ -166,7 +166,7 @@ func (m *MockRDSClient) addInstances(
 }
 
 // AddSnapshots add a list of snapshots to the mock
-func (m *MockRDSClient) AddSnapshots(
+func (m *RDSClient) AddSnapshots(
 	snapshots []*rds.DBSnapshot,
 ) {
 	m.dbSnapshots = []*rds.DBSnapshot{}
@@ -177,7 +177,7 @@ func (m *MockRDSClient) AddSnapshots(
 }
 
 // CreateDBSnapshot mocks rds.CreateDBSnapshot.
-func (m *MockRDSClient) CreateDBSnapshot(
+func (m *RDSClient) CreateDBSnapshot(
 	params *rds.CreateDBSnapshotInput,
 ) (
 	output *rds.CreateDBSnapshotOutput,
@@ -214,7 +214,7 @@ func (m *MockRDSClient) CreateDBSnapshot(
 }
 
 // DescribeDBSnapshots mocks rds.DescribeDBSnapshots.
-func (m MockRDSClient) DescribeDBSnapshots(
+func (m RDSClient) DescribeDBSnapshots(
 	describeParams *rds.DescribeDBSnapshotsInput,
 ) (
 	result *rds.DescribeDBSnapshotsOutput,
@@ -242,7 +242,7 @@ func (m MockRDSClient) DescribeDBSnapshots(
 }
 
 // DescribeDBInstances mocks rds.DescribeDBInstances.
-func (m *MockRDSClient) DescribeDBInstances(
+func (m *RDSClient) DescribeDBInstances(
 	describeParams *rds.DescribeDBInstancesInput,
 ) (
 	result *rds.DescribeDBInstancesOutput,
@@ -287,7 +287,7 @@ func (m *MockRDSClient) DescribeDBInstances(
 }
 
 // CreateDBInstance mocks rds.CreateDBInstance.
-func (m *MockRDSClient) CreateDBInstance(
+func (m *RDSClient) CreateDBInstance(
 	inputParams *rds.CreateDBInstanceInput,
 ) (
 	result *rds.CreateDBInstanceOutput,
@@ -343,7 +343,7 @@ func (m *MockRDSClient) CreateDBInstance(
 }
 
 // RestoreDBInstanceFromDBSnapshot mocks rds.RestoreDBInstanceFromDBSnapshot.
-func (m *MockRDSClient) RestoreDBInstanceFromDBSnapshot(
+func (m *RDSClient) RestoreDBInstanceFromDBSnapshot(
 	inputParams *rds.RestoreDBInstanceFromDBSnapshotInput,
 ) (
 	result *rds.RestoreDBInstanceFromDBSnapshotOutput,
@@ -382,7 +382,7 @@ func (m *MockRDSClient) RestoreDBInstanceFromDBSnapshot(
 }
 
 // ModifyDBInstance mocks rds.ModifyDBInstance.
-func (m *MockRDSClient) ModifyDBInstance(
+func (m *RDSClient) ModifyDBInstance(
 	params *rds.ModifyDBInstanceInput,
 ) (
 	out *rds.ModifyDBInstanceOutput,
@@ -416,9 +416,9 @@ func (m *MockRDSClient) ModifyDBInstance(
 	return
 }
 
-// NewMockRDSClient creates a MockRDSClient.
-func NewMockRDSClient() *MockRDSClient {
-	return &MockRDSClient{
+// NewRDSClient creates a RDSClient.
+func NewRDSClient() *RDSClient {
+	return &RDSClient{
 		dbInstances: []*rds.DBInstance{},
 		dbSnapshots: []*rds.DBSnapshot{},
 	}

--- a/pkg/odin/instance_test.go
+++ b/pkg/odin/instance_test.go
@@ -6,7 +6,7 @@ import(
 
 	"github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/poka-yoke/spaceflight/internal/test/mockRDSClient"
+	"github.com/poka-yoke/spaceflight/internal/test/mocks"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
@@ -42,7 +42,7 @@ func TestCloneDBInput(t *testing.T) {
 			err: nil,
 		},
 	}
-	svc := mockrdsclient.NewMockRDSClient()
+	svc := mocks.NewRDSClient()
 	svc.AddSnapshots([]*rds.DBSnapshot{exampleSnapshot1})
 	for _, tc := range tt {
 		res, err := tc.input.CloneDBInput(svc)
@@ -94,7 +94,7 @@ func TestCreateDBInput(t *testing.T) {
 			masterUsername: "owner",
 		},
 	}
-	svc := mockrdsclient.NewMockRDSClient()
+	svc := mocks.NewRDSClient()
 	svc.AddSnapshots([]*rds.DBSnapshot{exampleSnapshot1})
 	for _, tc := range tt {
 		res, err := tc.input.CreateDBInput()
@@ -258,7 +258,7 @@ func TestRestoreDBInput(t *testing.T) {
 			dbSnapshotIdentifier: "rds:production-2015-06-11",
 		},
 	}
-	svc := mockrdsclient.NewMockRDSClient()
+	svc := mocks.NewRDSClient()
 	svc.AddSnapshots([]*rds.DBSnapshot{exampleSnapshot1})
 	for _, tc := range tt {
 		res, err := tc.input.RestoreDBInput(svc)

--- a/pkg/odin/odin_test.go
+++ b/pkg/odin/odin_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/rds"
 
 	"github.com/poka-yoke/spaceflight/internal/test"
-	"github.com/poka-yoke/spaceflight/internal/test/mockRDSClient"
+	"github.com/poka-yoke/spaceflight/internal/test/mocks"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
@@ -58,7 +58,7 @@ var getLastSnapshotCases = []getLastSnapshotCase{
 }
 
 func TestGetLastSnapshot(t *testing.T) {
-	svc := mockrdsclient.NewMockRDSClient()
+	svc := mocks.NewRDSClient()
 	for _, test := range getLastSnapshotCases {
 		t.Run(
 			test.name,
@@ -191,7 +191,7 @@ func TestListSnapshots(t *testing.T) {
 		t.Run(
 			test.name,
 			func(t *testing.T) {
-				svc := mockrdsclient.NewMockRDSClient()
+				svc := mocks.NewRDSClient()
 				svc.AddSnapshots(test.snapshots)
 				actual, err := odin.ListSnapshots(
 					test.instanceID,

--- a/pkg/odin/odin_test.go
+++ b/pkg/odin/odin_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/poka-yoke/spaceflight/internal/test_case"
+	"github.com/poka-yoke/spaceflight/internal/test"
 	"github.com/poka-yoke/spaceflight/internal/test/mockRDSClient"
 	"github.com/poka-yoke/spaceflight/pkg/odin"
 )
 
 type getLastSnapshotCase struct {
-	testcase.TestCase
+	test.Case
 	name       string
 	identifier string
 	snapshots  []*rds.DBSnapshot
@@ -22,7 +22,7 @@ type getLastSnapshotCase struct {
 var getLastSnapshotCases = []getLastSnapshotCase{
 	// Get snapshot id by instance id
 	{
-		TestCase: testcase.TestCase{
+		Case: test.Case{
 			Expected:      exampleSnapshot1,
 			ExpectedError: "",
 		},
@@ -34,7 +34,7 @@ var getLastSnapshotCases = []getLastSnapshotCase{
 	},
 	// Get non-existing snapshot id by instance id
 	{
-		TestCase: testcase.TestCase{
+		Case: test.Case{
 			Expected:      nil,
 			ExpectedError: "No snapshot found for develop instance",
 		},
@@ -44,7 +44,7 @@ var getLastSnapshotCases = []getLastSnapshotCase{
 	},
 	// Get last snapshot id by instance id out of two
 	{
-		TestCase: testcase.TestCase{
+		Case: test.Case{
 			Expected:      exampleSnapshot3,
 			ExpectedError: "",
 		},
@@ -126,7 +126,7 @@ var exampleSnapshot4 = &rds.DBSnapshot{
 }
 
 type listSnapshotsCase struct {
-	testcase.TestCase
+	test.Case
 	name       string
 	snapshots  []*rds.DBSnapshot
 	instanceID string
@@ -135,7 +135,7 @@ type listSnapshotsCase struct {
 var listSnapshotsCases = []listSnapshotsCase{
 	// No snapshots for any instance
 	{
-		TestCase: testcase.TestCase{
+		Case: test.Case{
 			Expected:      []*rds.DBSnapshot{},
 			ExpectedError: "",
 		},
@@ -145,7 +145,7 @@ var listSnapshotsCases = []listSnapshotsCase{
 	},
 	// One instance, one snapshot
 	{
-		TestCase: testcase.TestCase{
+		Case: test.Case{
 			Expected:      []*rds.DBSnapshot{exampleSnapshot1},
 			ExpectedError: "",
 		},
@@ -155,7 +155,7 @@ var listSnapshotsCases = []listSnapshotsCase{
 	},
 	// Two instances, two snapshots
 	{
-		TestCase: testcase.TestCase{
+		Case: test.Case{
 			Expected: []*rds.DBSnapshot{
 				exampleSnapshot2,
 				exampleSnapshot1,
@@ -171,7 +171,7 @@ var listSnapshotsCases = []listSnapshotsCase{
 	},
 	// Instance selection
 	{
-		TestCase: testcase.TestCase{
+		Case: test.Case{
 			Expected: []*rds.DBSnapshot{
 				exampleSnapshot2,
 			},


### PR DESCRIPTION
This change improves:
- `testcase.TestCase` is now called `test.Case`
- `mockrdsclient.MockRDSClient` is now called `mocks.RDSClient`