### PR TITLE
Build artifacts pre-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 before_deploy:
+  # Build all artifacts
+  - go build ./cmd/...
   # Set up git user name and tag this commit
   - git config --local user.name "Travis"
   - git config --local user.email "Travis@poka-yoke.bot"


### PR DESCRIPTION
The releases are being created now, but the contents do not include
the built targets. Force the build of the artifacts so thay can be
published.