### PR TITLE
dnsbl: Add cache for reversed IP string

### DIFF
--- a/pkg/dnsbl/common.go
+++ b/pkg/dnsbl/common.go
@@ -16,6 +16,9 @@ var (
 	// Resolver allows to override the DNS resolver. Defaults to
 	// the standard library's default resolver.
 	Resolver = net.DefaultResolver
+	// reverserCache caches the reversing of IP Address members to
+	// avoid recomputation if the IP does not change
+	reverserCache = make(map[string]string)
 )
 
 // reverseAddress converts IP address into reversed address for query.
@@ -36,9 +39,14 @@ func reverseAddress(ipAddress string) string {
 // the BL. If the number of matches in the lookup were 0, it means not
 // present.
 func Query(ctx context.Context, provider, address string) int {
+	reverse, ok := reverserCache[address]
+	if !ok {
+		reverse = reverseAddress(address)
+		reverserCache[address] = reverse
+	}
 	queryAddress := fmt.Sprintf(
 		"%v.%v",
-		reverseAddress(address),
+		reverse,
 		provider,
 	)
 


### PR DESCRIPTION
Whenever we run a `dnsbl.Query` we reverse the IP address we are
asking about. If we check many different IP addresses against the same
provider we have to reverse each one, so it is unavoidable.

Nonetheless, our usual use-case is to check a small set of IPs against
a larger set of providers, so we are reversing the same addresses time
and again. This is not a costly operation as the networking cost is
much higher, but it is costly in memory allocations and garbage, as we
generate many strings unnecessarily.

This adds a cache for `dnsbl.Query()` so that we do not reverse the
same IP on each provider query call. The effect, as benchmarked,
basically halves the cost per call when the call is mocked (no network
involved).

```
[mbernabe@chip dnsbl]$ go test -bench=. -benchmem
goos: linux
goarch: amd64
pkg: github.com/poka-yoke/spaceflight/pkg/dnsbl
cpu: Intel(R) Core(TM) i7-8565U CPU @ 1.80GHz
BenchmarkQuery-8        	 2884080	       357.4 ns/op	     168 B/op	       7 allocs/op
BenchmarkQueryCache-8   	 6667069	       183.7 ns/op	      80 B/op	       4 allocs/op
PASS
ok  	github.com/poka-yoke/spaceflight/pkg/dnsbl	2.864s
```

A potential downside appears with long-running processes that accept
many different IPs, as the cache would then tend to grow over time (as
it is a very naive implementation). If that use case surfaced, we
could provide a configurable implementation, including a
`NullCache` (that always misses and is mostly a no-op) to prevent the
issue.

Here is the benchmark implementation (QueryCache is the new
implementation so it could compare to the previous one):

```go
func BenchmarkQueryCache(b *testing.B) {
	dnsbl.Resolver = nil // Do not resolve external addresses
	dnsbl.LookupHostFunc = mockLookupHost
	for i := 0; i < b.N; i++ {
		dnsbl.QueryCache(context.Background(), "positive.dnsbl.com", "127.0.0.1")
	}
}
```